### PR TITLE
[ethif] add the ability to capture packets sent to/received from the net...

### DIFF
--- a/direct/lib/ethif.mli
+++ b/direct/lib/ethif.mli
@@ -40,3 +40,19 @@ val sizeof_ethernet : int
 val set_ethernet_dst : string -> int -> OS.Io_page.t -> unit
 val set_ethernet_src : string -> int -> OS.Io_page.t -> unit
 val set_ethernet_ethertype : OS.Io_page.t -> int -> unit
+
+module Lwt_bounded_stream : sig
+  type 'a t
+
+  val get_available : 'a t -> 'a list
+
+  val nget : int -> 'a t -> 'a list Lwt.t
+end
+
+val get_captured_packets : t -> (float * OS.Io_page.t list) Lwt_bounded_stream.t
+(** A bounded stream of (timestamp * captured packet), suitable for analysis
+    or recording. *)
+
+val set_capture_limit : int -> t -> unit
+(** Set the maximum size of the bounded stream used for packet capture.
+    Packets which arrive when the stream is full are dropped. *)


### PR DESCRIPTION
...work

Packets read or written are pushed to an 'Lwt_bounded_stream' which will drop
rather than block when the stream is full. The default size of the
stream is 0, i.e. all packets are dropped i.e. capturing is disabled.

Clients which wish to process the packets should change the default stream
bound to more than 0 and then use "nget" in a blocking thread.
