### PR TITLE
Extend the promiscuous hook to capture in both directions on a running stack

### DIFF
--- a/direct/lib/ethif.mli
+++ b/direct/lib/ethif.mli
@@ -46,5 +46,9 @@ val set_ethernet_dst : string -> int -> OS.Io_page.t -> unit
 val set_ethernet_src : string -> int -> OS.Io_page.t -> unit
 val set_ethernet_ethertype : OS.Io_page.t -> int -> unit
 
-val set_promiscuous : t -> (Cstruct.buf -> unit Lwt.t) -> unit
+type packet =
+| Input of Cstruct.buf       (** always read as a whole chunk *)
+| Output of Cstruct.buf list (** written as a list of fragments *)
+
+val set_promiscuous : t -> (packet -> unit Lwt.t) -> unit
 val disable_promiscuous : t -> unit

--- a/direct/lib/manager.mli
+++ b/direct/lib/manager.mli
@@ -35,7 +35,7 @@ val configure: interface -> config -> unit Lwt.t
  
 val create : ?devs:int -> (t -> interface -> id -> unit Lwt.t) -> unit Lwt.t
 
-val set_promiscuous: t -> id -> (id -> Cstruct.buf -> unit Lwt.t) -> unit                                                              
+val set_promiscuous: t -> id -> (id -> Ethif.packet -> unit Lwt.t) -> unit                                                              
 val inject_packet : t -> id -> Cstruct.buf -> unit Lwt.t            
 
 val tcpv4_of_addr : t -> ipv4_addr option -> Tcp.Pcb.t list


### PR DESCRIPTION
We expose the function which performs the default input processing so that an app which has added a promiscuous hook can still call it, so the network stack behaves normally.

We call the promiscuous hook with outgoing traffic as well as incoming traffic for more complete logging potential.

(I've not tested this end-to-end yet)
