### PR TITLE
IPv4: fix the header length calculation

### DIFF
--- a/direct/lib/ipv4.ml
+++ b/direct/lib/ipv4.ml
@@ -108,11 +108,10 @@ let write t frame data =
   let buf = adjust_output_header ~tlen frame in
   Ethif.writev t.ethif [frame;data]
 
-let writev t frame bufs = 
-  let ihl = 5 in (* TODO options *)
-  let tlen = (ihl * 4) + (Cstruct.lenv bufs) in
-  adjust_output_header ~tlen frame;
-  Ethif.writev t.ethif (frame::bufs)
+let writev t ethernet_frame bufs =
+  let tlen = Cstruct.len ethernet_frame - Ethif.sizeof_ethernet + (Cstruct.lenv bufs) in
+  adjust_output_header ~tlen ethernet_frame;
+  Ethif.writev t.ethif (ethernet_frame::bufs)
  
 let input t buf =
   (* buf pointers to to start of IPv4 header here *)


### PR DESCRIPTION
By convention we have a single header buffer containing ethernet/IP/TCP...
and a list of payload fragments. When we calculat the IPv4 header length
we must sum the length of the payload fragments _and_ the length of everything
in the header buffer except the ethernet header length.

This fixes the bug where TCP headers appear to be missing in wireshark;
they are actually present on the wire but the parser is obeying the IP
header length field and truncating the packet before display.
