### PR TITLE
performance tweak - removed some unnecessary signalling between tcp threads

### DIFF
--- a/direct/lib/tcp/window.mli
+++ b/direct/lib/tcp/window.mli
@@ -34,6 +34,14 @@ val tx_una : t -> Sequence.t
 val tx_mss : t -> int
 val fast_rec : t -> bool
 
+val ack_serviced : t -> bool
+val ack_seq : t -> Sequence.t
+val ack_win : t -> int
+
+val set_ack_serviced : t -> bool -> unit
+val set_ack_seq : t -> Sequence.t -> unit
+val set_ack_win : t -> int -> unit
+
 (* rx_wnd: number of bytes we are willing to accept *)
 val rx_wnd : t -> int32
 val rx_wnd_unscaled : t -> int32


### PR DESCRIPTION
Previously every tcp ack received was being signalled to the TX thread
and since an mvar was being used for the signalling, the RX thread would
block till the TX side had processed the previously signalled ACK.  Fixed,
and also added a test to only signal if the ack has info that matters
to the TX thread.  Gives about a 15% speedup.
