### PR TITLE
Add missing functions to the socket backend

### DIFF
--- a/socket/lib/manager.ml
+++ b/socket/lib/manager.ml
@@ -80,3 +80,6 @@ let get_intf_mac t id =
   failwith "Socket mirage doesn't support dev mac address"
 let set_promiscuous t id f =
   failwith "Socket mirage doesn't support dev promiscuous mode"
+let get_intf_ipv4addr t id =
+  failwith "Socket mirage doesn't support get_intf_ipv4addr"
+

--- a/socket/lib/manager.mli
+++ b/socket/lib/manager.mli
@@ -69,3 +69,6 @@ val inject_packet : t -> id -> Cstruct.t -> unit Lwt.t
 val get_intf_name : t -> id -> string
 val get_intf_mac : t -> id -> Macaddr.t
 
+(** [get_intf_ipv4addr mgr id] returns the IPv4 address of interface
+    [id] if it exists, or raise [Not_found] otherwise. *)
+val get_intf_ipv4addr : t -> id -> Ipaddr.V4.t


### PR DESCRIPTION
One of the mirage_skeleton examples (tcp) makes use of functions present in direct but missing from socket. These patches add stubs to make the code compile. More work will be needed to make the code function.
