### PR TITLE
unix: fix `Eof on empty TCP.write

### DIFF
--- a/unix/tcpv4_socket.ml
+++ b/unix/tcpv4_socket.ml
@@ -84,8 +84,8 @@ let read fd =
 let rec write fd buf =
   Lwt_cstruct.write fd buf
   >>= function
-  | 0 -> return `Eof
   | n when n = Cstruct.len buf -> return (`Ok ())
+  | 0 -> return `Eof
   | n -> write fd (Cstruct.sub buf n (Cstruct.len buf - n))
 
 let writev fd bufs =


### PR DESCRIPTION
Currently writing a `Cstruct.t` of length 0 using the socket backend results in an `Eof`. While this is not necessarily bad in itself, it is different from what direct backend does.

This fixes the divergence in semantics by making socket backend return `Ok`.

(N.B. Sorry, I originally pushed the branch to the main repo by mistake. :blush:)
