### PR TITLE
Ipv6: Fix compilation on 4.01.0

### DIFF
--- a/lib/ipv6.ml
+++ b/lib/ipv6.ml
@@ -56,7 +56,7 @@ module Ipv6_wire = Wire_structs.Ipv6_wire
 
 (* This is temporary. See https://github.com/mirage/ocaml-ipaddr/pull/36 *)
 module Ipaddr = struct
-  include Ipaddr
+  include Ipaddr.V6
   let of_cstruct cs =
     let hihi = Cstruct.BE.get_uint32 cs 0 in
     let hilo = Cstruct.BE.get_uint32 cs 4 in

--- a/lib/ndpv6.mli
+++ b/lib/ndpv6.mli
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Ipaddr = Ipaddr.V6
-
 (** Address List management.
 
     An address can be in one of three states: {em tentative}, {em preferred},
@@ -31,15 +29,15 @@ module AddressList : sig
   val empty: t
   (** An empty address list. *)
 
-  val to_list: t -> Ipaddr.t list
+  val to_list: t -> Ipaddr.V6.t list
   (** Return the list of bound addresses.  This does not include tentative
       addresses. *)
 
-  val select_source: t -> dst:Ipaddr.t -> Ipaddr.t
+  val select_source: t -> dst:Ipaddr.V6.t -> Ipaddr.V6.t
   (** Source Selection *)
 
   val tick: t -> now:float -> retrans_timer:float ->
-    t * [> `Sleep of float | `SendNS of [> `Unspecified ] * Ipaddr.t * Ipaddr.t ] list
+    t * [> `Sleep of float | `SendNS of [> `Unspecified ] * Ipaddr.V6.t * Ipaddr.V6.t ] list
   (** [tick al now rt] performs the periodic upkeep of the address list.  This
       means: 1) deprecating (resp. expiring) addresses whose preferred (resp. valid)
       lifetimes have elapsed; 2) sending repeated NS to verify that a TENTATIVE
@@ -49,12 +47,12 @@ module AddressList : sig
   (** [expired al now] is [true] if there is some address in the list whose
       valid lifetime has elapsed and [false] otherwise. *)
 
-  val is_my_addr: t -> Ipaddr.t -> bool
+  val is_my_addr: t -> Ipaddr.V6.t -> bool
   (** [is_my_addr al ip] is [true] if [ip] is an address assigned to this list.
       In particular this means that it is not TENTATIVE. *)
 
-  val add: t -> now:float -> retrans_timer:float -> lft:(float * float option) option -> Ipaddr.t ->
-    t * [> `Sleep of float | `SendNS of [> `Unspecified ] * Ipaddr.t * Ipaddr.t ] list
+  val add: t -> now:float -> retrans_timer:float -> lft:(float * float option) option -> Ipaddr.V6.t ->
+    t * [> `Sleep of float | `SendNS of [> `Unspecified ] * Ipaddr.V6.t * Ipaddr.V6.t ] list
   (** [add al now rt lft ip] marks the address [ip] as TENTATIVE and beings
       Duplicate Address Detection (DAD) by sending Neighbor Solicitation
       messages to [ip] to try to determine if this address is already assigned
@@ -66,12 +64,12 @@ module AddressList : sig
       If the address is already bound or in the process of being bound, nothing
       happens. *)
 
-  val configure: t -> now:float -> retrans_timer:float -> lft:(float * float option) option -> Macaddr.t -> Ipaddr.Prefix.t ->
-    t * [> `Sleep of float | `SendNS of [> `Unspecified ] * Ipaddr.t * Ipaddr.t ] list
+  val configure: t -> now:float -> retrans_timer:float -> lft:(float * float option) option -> Macaddr.t -> Ipaddr.V6.Prefix.t ->
+    t * [> `Sleep of float | `SendNS of [> `Unspecified ] * Ipaddr.V6.t * Ipaddr.V6.t ] list
   (** [configure t now rt lft mac pfx] begins the process of assigning a
       globally unique address with prefix [pfx]. *)
 
-  val handle_na: t -> Ipaddr.t -> t
+  val handle_na: t -> Ipaddr.V6.t -> t
   (** [handle_na al ip] handles a Neighbor Advertisement which has arrived from
       [ip].  If [ip] is a TENTATIVE address in [al] then it means that DAD has
       failed and [ip] should not be bound. *)
@@ -80,12 +78,12 @@ end
 module PrefixList : sig
   type t
   val link_local: t
-  val to_list: t -> Ipaddr.Prefix.t list
+  val to_list: t -> Ipaddr.V6.Prefix.t list
   val expired: t -> now:float -> bool
   val tick: t -> now:float -> t
-  val is_local: t -> Ipaddr.t -> bool
-  val add: t -> now:float -> Ipaddr.Prefix.t -> vlft:float option -> t
-  val handle_ra: t -> now:float -> vlft:float option -> Ipaddr.Prefix.t ->
+  val is_local: t -> Ipaddr.V6.t -> bool
+  val add: t -> now:float -> Ipaddr.V6.Prefix.t -> vlft:float option -> t
+  val handle_ra: t -> now:float -> vlft:float option -> Ipaddr.V6.Prefix.t ->
     t * [> `Sleep of float ] list
 end
 
@@ -93,26 +91,26 @@ module NeighborCache : sig
   type t
   val empty: t
   val tick: t -> now:float -> retrans_timer:float ->
-    t * [> `Sleep of float | `SendNS of [> `Specified ] * Ipaddr.t * Ipaddr.t | `CancelQueued of Ipaddr.t ] list
-  val handle_ns: t -> src:Ipaddr.t -> Macaddr.t ->
-    t * [> `SendQueued of Ipaddr.t * Macaddr.t ] list
-  val handle_ra: t -> src:Ipaddr.t -> Macaddr.t ->
-    t * [> `SendQueued of Ipaddr.t * Macaddr.t ] list
-  val handle_na: t -> now:float -> reachable_time:float -> rtr:bool -> sol:bool -> ovr:bool -> tgt:Ipaddr.t -> lladdr:Macaddr.t option ->
-    t * [> `Sleep of float | `SendQueued of Ipaddr.t * Macaddr.t ] list
-  val query: t -> now:float -> reachable_time:float -> Ipaddr.t ->
-    t * Macaddr.t option * [> `Sleep of float | `SendNS of [> `Specified ] * Ipaddr.t * Ipaddr.t ] list
-  val reachable: t -> Ipaddr.t -> bool
+    t * [> `Sleep of float | `SendNS of [> `Specified ] * Ipaddr.V6.t * Ipaddr.V6.t | `CancelQueued of Ipaddr.V6.t ] list
+  val handle_ns: t -> src:Ipaddr.V6.t -> Macaddr.t ->
+    t * [> `SendQueued of Ipaddr.V6.t * Macaddr.t ] list
+  val handle_ra: t -> src:Ipaddr.V6.t -> Macaddr.t ->
+    t * [> `SendQueued of Ipaddr.V6.t * Macaddr.t ] list
+  val handle_na: t -> now:float -> reachable_time:float -> rtr:bool -> sol:bool -> ovr:bool -> tgt:Ipaddr.V6.t -> lladdr:Macaddr.t option ->
+    t * [> `Sleep of float | `SendQueued of Ipaddr.V6.t * Macaddr.t ] list
+  val query: t -> now:float -> reachable_time:float -> Ipaddr.V6.t ->
+    t * Macaddr.t option * [> `Sleep of float | `SendNS of [> `Specified ] * Ipaddr.V6.t * Ipaddr.V6.t ] list
+  val reachable: t -> Ipaddr.V6.t -> bool
 end
 
 module RouterList : sig
   type t
   val empty: t
-  val to_list: t -> Ipaddr.t list
-  val add: t -> now:float -> ?lifetime:float -> Ipaddr.t -> t
+  val to_list: t -> Ipaddr.V6.t list
+  val add: t -> now:float -> ?lifetime:float -> Ipaddr.V6.t -> t
   val tick: t -> now:float -> t
-  val handle_ra: t -> now:float -> src:Ipaddr.t -> lft:float ->
+  val handle_ra: t -> now:float -> src:Ipaddr.V6.t -> lft:float ->
     t * [> `Sleep of float ] list
-  val add: t -> now:float -> Ipaddr.t -> t
-  val select: t -> (Ipaddr.t -> bool) -> Ipaddr.t -> Ipaddr.t * t
+  val add: t -> now:float -> Ipaddr.V6.t -> t
+  val select: t -> (Ipaddr.V6.t -> bool) -> Ipaddr.V6.t -> Ipaddr.V6.t * t
 end


### PR DESCRIPTION
Module aliases are unsupported in .mli files in 4.01.0.
