### PR TITLE
Arp state machine

### DIFF
--- a/lib/arpv4.ml
+++ b/lib/arpv4.ml
@@ -94,7 +94,7 @@ module Make (Ethif : V1_LWT.ETHIF) (Time : V1_LWT.TIME) = struct
     |2 -> (* Reply *)
       let spa = Ipaddr.V4.of_int32 (get_arp_spa frame) in
       let sha = Macaddr.of_bytes_exn (copy_arp_sha frame) in
-      printf "ARP: updating %s -> %s\n%!" 
+      printf "ARP: updating %s -> %s\n%!"
         (Ipaddr.V4.to_string spa) (Macaddr.to_string sha);
       (* If we have pending entry, notify the waiters that answer is ready *)
       if Hashtbl.mem t.pending spa then begin

--- a/lib/arpv4.ml
+++ b/lib/arpv4.ml
@@ -55,7 +55,7 @@ module Make (Ethif : V1_LWT.ETHIF) (Time : V1_LWT.TIME) = struct
     Op_reply
     } as uint16_t
 
-  let arp_timeout = 5. (* 60. *) (* age entries out of cache after this many seconds *)
+  let arp_timeout = 60. (* age entries out of cache after this many seconds *)
   let probe_repeat_delay = 1.5 (* per rfc5227, 2s >= probe_repeat_delay >= 1s *)
   let probe_num = 3 (* how many probes to send before giving up *)
 

--- a/lib/arpv4.mli
+++ b/lib/arpv4.mli
@@ -17,7 +17,7 @@
 
 (** INTERNAL: ARP protocol. *)
 
-module Make (Ethif : V1_LWT.ETHIF) : sig
+module Make (Ethif : V1_LWT.ETHIF) (Time : V1_LWT.TIME) : sig
   (** Type of an ARP record. ARP records are included in Ethif.t
       values. They contain, among other bits, a list of bound IPs, and a
       IPv4 -> MAC hashtbl. *)
@@ -50,8 +50,9 @@ module Make (Ethif : V1_LWT.ETHIF) : sig
 
   (** [query arp ip] queries the cache in [arp] for an ARP entry
       corresponding to [ip], which may result in the sender sleeping
-      waiting for a response. *)
-  val query: t -> Ipaddr.V4.t -> Macaddr.t Lwt.t
+      waiting for a response.  After a reasonable attempt to resolve non-cached
+      entries has been made, the thread will return with None. *)
+  val query: t -> Ipaddr.V4.t -> (Macaddr.t option) Lwt.t
 
   (** Prettyprint cache contents *)
   val prettyprint: t -> unit

--- a/lib/ipv4.ml
+++ b/lib/ipv4.ml
@@ -17,9 +17,9 @@
 open Lwt
 open Printf
 
-module Make(Ethif : V1_LWT.ETHIF) = struct
+module Make(Ethif : V1_LWT.ETHIF) (Time : V1_LWT.TIME) = struct
 
-  module Arpv4 = Arpv4.Make (Ethif)
+  module Arpv4 = Arpv4.Make (Ethif) (Time)
 
   (** IO operation errors *)
   type error = [
@@ -68,20 +68,28 @@ module Make(Ethif : V1_LWT.ETHIF) = struct
       Bytes.set macb 5 (Bytes.get ipb 3);
       Macaddr.of_bytes_exn macb
 
-    let destination_mac t =
-      function
+    let destination_mac t ip =
+      let fail_arp reason = 
+          printf "IPv4: %s %s\n%!" reason (Ipaddr.V4.to_string ip);
+          fail (No_route_to_destination_address ip)
+      in
+      match ip with
       |ip when ip = Ipaddr.V4.broadcast || ip = Ipaddr.V4.any -> (* Broadcast *)
         return Macaddr.broadcast
-      |ip when is_local t ip -> (* Local *)
-        Arpv4.query t.arp ip
       |ip when Ipaddr.V4.is_multicast ip ->
         return (mac_of_multicast ip)
-      |ip -> begin (* Gateway *)
-          match t.gateways with
-          |hd::_ -> Arpv4.query t.arp hd
-          |[] ->
-            printf "IP.output: no route to %s\n%!" (Ipaddr.V4.to_string ip);
-            fail (No_route_to_destination_address ip)
+      |ip when is_local t ip -> (* Local *) begin
+        Arpv4.query t.arp ip >>= fun mac -> match mac with
+        | None -> fail_arp "Could not resolve local address"
+        | Some m -> return m
+        end
+      |ip -> begin (* Access via gateway *)
+        match t.gateways with
+        |[] -> fail_arp "No gateway provided by which to reach remote address"
+        |hd::_ -> 
+          Arpv4.query t.arp hd >>= fun mac -> match mac with
+          | None -> fail_arp "Could not resolve address of configured gateway"
+          | Some m -> return m
         end
   end
 

--- a/lib/ipv4.mli
+++ b/lib/ipv4.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make ( N:V1_LWT.ETHIF ) : V1_LWT.IPV4 with type ethif = N.t
+module Make ( N:V1_LWT.ETHIF ) (T:V1_LWT.TIME) : V1_LWT.IPV4 with type ethif = N.t

--- a/unix/ipv4_unix.ml
+++ b/unix/ipv4_unix.ml
@@ -1,1 +1,1 @@
-include Ipv4.Make(Ethif_unix)
+include Ipv4.Make(Ethif_unix)(OS.Time)


### PR DESCRIPTION
Improve ARP handling for IPv4 as follows:

* Create ARP cache entries for unsolicited (gratuitous) ARP replies.  Previously, receipt of these packets was noted in the console output but no entries were made in the ARP cache.
* Time out entries in the ARP cache after 60 seconds.
* If no reply to an ARP request is received within 1.5 seconds, send another ARP request.  A total of 3 ARP requests will be sent before giving up.
* In Ipv4, throw exception No_route_to_destination_address if a local address could not be resolved.  Previously, this exception was thrown only if a connection attempt was made to a non-local unicast address and no gateways were configured; it will now also be thrown if a gateway is configured but does not respond to ARP requests, or a local unicast address does not respond to ARP requests.  (Alternate suggestions for handling this are welcome.)