### PR TITLE
release 2.2.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,11 @@
-2.2.3 (2015-03-04):
+2.2.3 (2015-03-09):
 * Add ICMPv6 error reporting functions (#101)
 * Add universal IP address converters (#108)
 * Add `error_message` functions for human-readable errors (#98)
 * Improve debug logging for ICMP Destination Unreachable packets.
 * Filter incoming frames by MAC address to stop sending unnecessary RSTs. (#114)
 * Unhook unused modules `Sliding_window` and `Profiler` from the build. (#112)
+* Add an explicit `connect` method to the signatures. (#100) 
 
 2.2.2 (2015-01-11):
 * Readded tracing and ARP fixes which got accidentally reverted in the IPv6 merge. (#96)

--- a/lib/ethif.mli
+++ b/lib/ethif.mli
@@ -15,4 +15,7 @@
  *
  *)
 
-module Make ( N:V1_LWT.NETWORK ) : V1_LWT.ETHIF with type netif = N.t
+module Make ( N:V1_LWT.NETWORK ) : sig
+  include V1_LWT.ETHIF with type netif = N.t
+  val connect : netif -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/lib/ipv4.mli
+++ b/lib/ipv4.mli
@@ -14,4 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make ( N:V1_LWT.ETHIF ) : V1_LWT.IPV4 with type ethif = N.t
+module Make ( N:V1_LWT.ETHIF ) : sig
+  include V1_LWT.IPV4 with type ethif = N.t
+  val connect : ethif -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/lib/ipv6.mli
+++ b/lib/ipv6.mli
@@ -14,4 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (E : V1_LWT.ETHIF) (T : V1_LWT.TIME) (C : V1.CLOCK) : V1_LWT.IPV6 with type ethif = E.t
+module Make (E : V1_LWT.ETHIF) (T : V1_LWT.TIME) (C : V1.CLOCK) : sig
+  include V1_LWT.IPV6 with type ethif = E.t
+  val connect : ethif -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -140,24 +140,10 @@ struct
         ~ipv6:(fun _ -> return_unit)
         t.ethif)
 
-  let connect id =
+  let connect id ethif ipv4 udpv4 tcpv4 =
     let { V1_LWT.console = c; interface = netif; mode; _ } = id in
-    let or_error fn t err =
-      fn t
-      >>= function
-      | `Error _ -> fail (Failure err)
-      | `Ok r -> return r
-    in
     Console.log_s c "Manager: connect"
     >>= fun () ->
-    or_error Ethif.connect netif "ethif"
-    >>= fun ethif ->
-    or_error Ipv4.connect ethif "ipv4"
-    >>= fun ipv4 ->
-    or_error Udpv4.connect ipv4 "udpv4"
-    >>= fun udpv4 ->
-    or_error Tcpv4.connect ipv4 "tcpv4"
-    >>= fun tcpv4 ->
     let udpv4_listeners = Hashtbl.create 7 in
     let tcpv4_listeners = Hashtbl.create 7 in
     let t = { id; c; mode; netif; ethif; ipv4; tcpv4; udpv4;

--- a/lib/tcpip_stack_direct.mli
+++ b/lib/tcpip_stack_direct.mli
@@ -29,13 +29,16 @@ module Make
     (Ethif   : V1_LWT.ETHIF with type netif = Netif.t)
     (Ipv4    : V1_LWT.IPV4 with type ethif = Ethif.t)
     (Udpv4   : UDPV4_DIRECT with type ip = Ipv4.t)
-    (Tcpv4   : TCPV4_DIRECT with type ip = Ipv4.t) :
-  V1_LWT.STACKV4
-  with type console = Console.t
-   and type netif   = Netif.t
-   and type mode    = V1_LWT.direct_stack_config
-   and type udpv4   = Udpv4.t
-   and type tcpv4   = Tcpv4.t
-   and type ipv4    = Ipv4.t
-   and module TCPV4 = Tcpv4
-   and module UDPV4 = Udpv4
+    (Tcpv4   : TCPV4_DIRECT with type ip = Ipv4.t) : sig
+  include V1_LWT.STACKV4
+    with type console = Console.t
+     and type netif   = Netif.t
+     and type mode    = V1_LWT.direct_stack_config
+     and type udpv4   = Udpv4.t
+     and type tcpv4   = Tcpv4.t
+     and type ipv4    = Ipv4.t
+     and module TCPV4 = Tcpv4
+     and module UDPV4 = Udpv4
+  val connect : (console, netif, mode) V1_LWT.stackv4_config ->
+    Ethif.t -> Ipv4.t -> Udpv4.t -> Tcpv4.t -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/lib/udp.mli
+++ b/lib/udp.mli
@@ -15,7 +15,10 @@
  *)
 
 
-module Make ( IP:V1_LWT.IP ) : V1_LWT.UDP
-  with type ip = IP.t
-   and type ipaddr = IP.ipaddr
-   and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
+module Make ( IP:V1_LWT.IP ) : sig
+  include V1_LWT.UDP
+    with type ip = IP.t
+     and type ipaddr = IP.ipaddr
+     and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
+  val connect : ip -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/opam
+++ b/opam
@@ -1,9 +1,10 @@
 opam-version: "1.2"
+name: "tcpip"
+version: "2.2.3"
 maintainer:   "anil@recoil.org"
 homepage:     "https://github.com/mirage/mirage-tcpip"
 dev-repo:     "https://github.com/mirage/mirage-tcpip.git"
 bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
-version: "2.2.3"
 authors: [
   "Anil Madhavapeddy"
   "Balraj Singh"

--- a/tcp/flow.mli
+++ b/tcp/flow.mli
@@ -15,7 +15,10 @@
  *)
 
 
-module Make (IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.CLOCK)(R:V1.RANDOM) : V1_LWT.TCP
-  with type ip = IP.t
-   and type ipaddr = IP.ipaddr
-   and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
+module Make (IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.CLOCK)(R:V1.RANDOM) : sig
+  include V1_LWT.TCP
+    with type ip = IP.t
+     and type ipaddr = IP.ipaddr
+     and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
+  val connect : ip -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/unix/tcpip_stack_socket.ml
+++ b/unix/tcpip_stack_socket.ml
@@ -122,20 +122,10 @@ module Make(Console:V1_LWT.CONSOLE) = struct
     let t, _ = Lwt.task () in
     t (* TODO cancellation *)
 
-  let connect id =
+  let connect id udpv4 tcpv4 =
     let { V1_LWT.console = c; interface; _ } = id in
-    let or_error fn t err =
-      fn t
-      >>= function
-      | `Error _ -> fail (Failure err)
-      | `Ok r -> return r
-    in
     Console.log_s c "Manager: connect"
     >>= fun () ->
-    or_error Udpv4.connect None "udpv4"
-    >>= fun udpv4 ->
-    or_error Tcpv4.connect None "tcpv4"
-    >>= fun tcpv4 ->
     let udpv4_listeners = Hashtbl.create 7 in
     let tcpv4_listeners = Hashtbl.create 7 in
     let t = { id; c; tcpv4; udpv4; udpv4_listeners; tcpv4_listeners } in

--- a/unix/tcpip_stack_socket.mli
+++ b/unix/tcpip_stack_socket.mli
@@ -14,13 +14,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make(Console:V1_LWT.CONSOLE) : V1_LWT.STACKV4
-  with type console = Console.t
-   and type netif   = Ipaddr.V4.t list
-   and type mode    = unit
-   and type tcpv4   = Tcpv4_socket.t
-   and type udpv4   = Udpv4_socket.t
-   and type ipv4    = Ipaddr.V4.t option
-   and module UDPV4 = Udpv4_socket
-   and module TCPV4 = Tcpv4_socket
-   and module IPV4  = Ipv4_socket
+module Make(Console:V1_LWT.CONSOLE) : sig
+  include V1_LWT.STACKV4
+    with type console = Console.t
+     and type netif   = Ipaddr.V4.t list
+     and type mode    = unit
+     and type tcpv4   = Tcpv4_socket.t
+     and type udpv4   = Udpv4_socket.t
+     and type ipv4    = Ipaddr.V4.t option
+     and module UDPV4 = Udpv4_socket
+     and module TCPV4 = Tcpv4_socket
+     and module IPV4  = Ipv4_socket
+  val connect : (console, netif, mode) V1_LWT.stackv4_config ->
+    Udpv4_socket.t -> Tcpv4_socket.t -> [> `Ok of t | `Error of error ] Lwt.t
+end

--- a/unix/tcpv4_socket.mli
+++ b/unix/tcpv4_socket.mli
@@ -18,3 +18,4 @@ include V1_LWT.TCP with type ip = Ipaddr.V4.t option
                     and type ipaddr = Ipaddr.V4.t
                     and type ipinput = unit Lwt.t
                     and type flow = Lwt_unix.file_descr
+val connect : ip -> [> `Ok of t | `Error of error ] Lwt.t


### PR DESCRIPTION
* Add ICMPv6 error reporting functions (#101)
* Add universal IP address converters (#108)
* Add `error_message` functions for human-readable errors (#98)
* Improve debug logging for ICMP Destination Unreachable packets.
* Filter incoming frames by MAC address to stop sending unnecessary RSTs. (#114)
* Unhook unused modules `Sliding_window` and `Profiler` from the build. (#112)
* Add an explicit `connect` method to the signatures. (#100)