### PR TITLE
check length of received ethernet frame (to avoid cstruct exceptions)

### DIFF
--- a/lib/ethif.ml
+++ b/lib/ethif.ml
@@ -49,9 +49,9 @@ module Make(Netif : V1_LWT.NETWORK) = struct
         | Some Wire_structs.ARP -> arpv4 frame
         | Some Wire_structs.IPv4 -> ipv4 payload
         | Some Wire_structs.IPv6 -> ipv6 payload
-        | None -> return_unit (* TODO: default ethertype payload handler *)
+        | None -> Lwt.return_unit (* TODO: default ethertype payload handler *)
       end
-    | _ -> return_unit
+    | _ -> Lwt.return_unit
 
   let write t frame =
     MProf.Trace.label "ethif.write";

--- a/lib/ethif.ml
+++ b/lib/ethif.ml
@@ -49,11 +49,13 @@ module Make(Netif : V1_LWT.NETWORK) = struct
         let payload = Cstruct.shift frame Wire_structs.sizeof_ethernet
         and ethertype = Wire_structs.get_ethernet_ethertype frame
         in
-        Wire_structs.(match int_to_ethertype ethertype with
+        Wire_structs.(
+          match int_to_ethertype ethertype with
           | Some ARP -> arpv4 frame
           | Some IPv4 -> ipv4 payload
           | Some IPv6 -> ipv6 payload
-          | None -> (* TODO default etype payload *) return_unit)
+          | None -> return_unit (* TODO default etype payload *)
+          )
       | _ -> return_unit
     else
       return_unit

--- a/lib/wire_structs.ml
+++ b/lib/wire_structs.ml
@@ -10,6 +10,19 @@ cenum ethertype {
     IPv6 = 0x86dd;
   } as uint16_t
 
+let parse_ethernet_frame frame =
+  if Cstruct.len frame >= 60 then
+    (* minimum payload is 46 + source + destination + type *)
+    let payload = Cstruct.shift frame sizeof_ethernet
+    and typ = get_ethernet_ethertype frame
+    in
+    match Macaddr.of_bytes (copy_ethernet_dst frame) with
+    | Some destination_mac -> Some (int_to_ethertype typ, destination_mac, payload)
+    | None -> None
+  else
+    None
+
+
 cstruct udp {
     uint16_t source_port;
     uint16_t dest_port;

--- a/lib/wire_structs.ml
+++ b/lib/wire_structs.ml
@@ -11,8 +11,8 @@ cenum ethertype {
   } as uint16_t
 
 let parse_ethernet_frame frame =
-  if Cstruct.len frame >= 60 then
-    (* minimum payload is 46 + source + destination + type *)
+  if Cstruct.len frame >= 14 then
+    (* source + destination + type = 14 *)
     let payload = Cstruct.shift frame sizeof_ethernet
     and typ = get_ethernet_ethertype frame
     and dst = Macaddr.of_bytes_exn (copy_ethernet_dst frame)

--- a/lib/wire_structs.ml
+++ b/lib/wire_structs.ml
@@ -15,10 +15,9 @@ let parse_ethernet_frame frame =
     (* minimum payload is 46 + source + destination + type *)
     let payload = Cstruct.shift frame sizeof_ethernet
     and typ = get_ethernet_ethertype frame
+    and dst = Macaddr.of_bytes_exn (copy_ethernet_dst frame)
     in
-    match Macaddr.of_bytes (copy_ethernet_dst frame) with
-    | Some destination_mac -> Some (int_to_ethertype typ, destination_mac, payload)
-    | None -> None
+    Some (int_to_ethertype typ, dst, payload)
   else
     None
 

--- a/lib/wire_structs.ml
+++ b/lib/wire_structs.ml
@@ -4,16 +4,11 @@ cstruct ethernet {
     uint16_t       ethertype
   } as big_endian
 
-let ethertype_to_protocol = function
-  | 0x0806 -> Some `ARP
-  | 0x0800 -> Some `IPv4
-  | 0x86dd -> Some `IPv6
-  | _ -> None
-
-let protocol_to_ethertype = function
-  | `ARP -> 0x0806
-  | `IPv4 -> 0x0800
-  | `IPv6 -> 0x86dd
+cenum ethertype {
+    ARP  = 0x0806;
+    IPv4 = 0x0800;
+    IPv6 = 0x86dd;
+  } as uint16_t
 
 cstruct udp {
     uint16_t source_port;

--- a/lib/wire_structs.ml
+++ b/lib/wire_structs.ml
@@ -4,6 +4,17 @@ cstruct ethernet {
     uint16_t       ethertype
   } as big_endian
 
+let ethertype_to_protocol = function
+  | 0x0806 -> Some `ARP
+  | 0x0800 -> Some `IPv4
+  | 0x86dd -> Some `IPv6
+  | _ -> None
+
+let protocol_to_ethertype = function
+  | `ARP -> 0x0806
+  | `IPv4 -> 0x0800
+  | `IPv6 -> 0x86dd
+
 cstruct udp {
     uint16_t source_port;
     uint16_t dest_port;


### PR DESCRIPTION
provide ethertype_to_protocol / protocol_to_ethertype conversion
cleanup code

should be straightforward. please let me know if you consider this code to be less readable