### PR TITLE
Arp improvements

### DIFF
--- a/lib/arpv4.ml
+++ b/lib/arpv4.ml
@@ -212,8 +212,8 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
       let rec retry n () =
         (* First request, so send a query packet *)
         output_probe t ip >>= fun () ->
-        Lwt.pick [ (Lwt.protected response >>= fun _ -> Lwt.return `Ok);
-                   (Time.sleep probe_repeat_delay >>= fun () -> Lwt.return `Timeout) ] >>= function
+        Lwt.choose [ (response >>= fun _ -> Lwt.return `Ok);
+                     (Time.sleep probe_repeat_delay >>= fun () -> Lwt.return `Timeout) ] >>= function
         | `Ok -> Lwt.return_unit
         | `Timeout ->
           if n < probe_num then

--- a/lib/arpv4.ml
+++ b/lib/arpv4.ml
@@ -19,6 +19,9 @@ open Lwt
 open Printf
 
 module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = struct
+
+  exception ARP_timeout of Ipaddr.V4.t
+
   type arp = {
     op: [ `Request |`Reply |`Unknown of int ];
     sha: Macaddr.t;
@@ -223,7 +226,7 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
             retry n ()
           end else begin
             Hashtbl.remove t.cache ip;
-            Lwt.wakeup_exn waker Not_found;
+            Lwt.wakeup_exn waker (ARP_timeout ip);
             Lwt.return_unit
           end
       in

--- a/lib/arpv4.ml
+++ b/lib/arpv4.ml
@@ -30,7 +30,7 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
   (* TODO implement the full ARP state machine (pending, failed, timer thread, etc) *)
 
   type entry =
-    | Pending of Macaddr.t Lwt_condition.t
+    | Pending of Macaddr.t option Lwt_condition.t
     | Confirmed of float * Macaddr.t
 
   type t = {
@@ -92,7 +92,7 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
       match Hashtbl.find t.cache ip with
       | Pending cond ->
         Hashtbl.replace t.cache ip (Confirmed (expire, mac));
-        Lwt_condition.broadcast cond mac
+        Lwt_condition.broadcast cond (Some mac)
       | Confirmed _ ->
         Hashtbl.replace t.cache ip (Confirmed (expire, mac))
     with
@@ -199,9 +199,10 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
   (* Query the cache for an ARP entry, which may result in the sender sleeping
      waiting for a response *)
   let query t ip =
+    let wait c = Lwt_condition.wait c >>= function None -> Lwt.fail Not_found | Some mac -> Lwt.return mac in
     try match Hashtbl.find t.cache ip with
       | Pending cond ->
-        Lwt_condition.wait cond
+        wait cond
       | Confirmed (_, mac) ->
         Lwt.return mac
     with
@@ -209,9 +210,23 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
       let cond = MProf.Trace.named_condition "ARP response" in
       (* printf "ARP query: %s -> [probe]\n%!" (Ipaddr.V4.to_string ip); *)
       Hashtbl.add t.cache ip (Pending cond);
-      let response = Lwt_condition.wait cond in
-      (* First request, so send a query packet *)
-      output_probe t ip >>= fun () ->
+      let response = wait cond in
+      let rec retry n () =
+        (* First request, so send a query packet *)
+        output_probe t ip >>= fun () ->
+        Lwt.pick [ (Lwt.protected response >>= fun _ -> Lwt.return `Ok);
+                   (Time.sleep probe_repeat_delay >>= fun () -> Lwt.return `Timeout) ] >>= function
+        | `Ok -> Lwt.return_unit
+        | `Timeout ->
+          if n < probe_num then
+            retry (n+1) ()
+          else begin
+            Hashtbl.remove t.cache ip;
+            Lwt_condition.broadcast cond None;
+            Lwt.return_unit
+          end
+      in
+      Lwt.async (retry 0);
       response
 
   let create ethif =

--- a/lib/arpv4.mli
+++ b/lib/arpv4.mli
@@ -19,8 +19,6 @@
 
 module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) : sig
 
-  exception ARP_timeout of Ipaddr.V4.t
-
   (** Type of an ARP record. ARP records are included in Ethif.t
       values. They contain, among other bits, a list of bound IPs, and a
       IPv4 -> MAC hashtbl. *)
@@ -54,7 +52,7 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) : sig
   (** [query arp ip] queries the cache in [arp] for an ARP entry
       corresponding to [ip], which may result in the sender sleeping
       waiting for a response. *)
-  val query: t -> Ipaddr.V4.t -> Macaddr.t Lwt.t
+  val query: t -> Ipaddr.V4.t -> [ `Ok of Macaddr.t | `Timeout ] Lwt.t
 
   (** Prettyprint cache contents *)
   val prettyprint: t -> unit

--- a/lib/arpv4.mli
+++ b/lib/arpv4.mli
@@ -18,6 +18,9 @@
 (** INTERNAL: ARP protocol. *)
 
 module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) : sig
+
+  exception ARP_timeout of Ipaddr.V4.t
+
   (** Type of an ARP record. ARP records are included in Ethif.t
       values. They contain, among other bits, a list of bound IPs, and a
       IPv4 -> MAC hashtbl. *)

--- a/lib/arpv4.mli
+++ b/lib/arpv4.mli
@@ -17,7 +17,7 @@
 
 (** INTERNAL: ARP protocol. *)
 
-module Make (Ethif : V1_LWT.ETHIF) : sig
+module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) : sig
   (** Type of an ARP record. ARP records are included in Ethif.t
       values. They contain, among other bits, a list of bound IPs, and a
       IPv4 -> MAC hashtbl. *)

--- a/lib/ipv4.ml
+++ b/lib/ipv4.ml
@@ -17,9 +17,9 @@
 open Lwt
 open Printf
 
-module Make(Ethif : V1_LWT.ETHIF) = struct
+module Make(Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = struct
 
-  module Arpv4 = Arpv4.Make (Ethif)
+  module Arpv4 = Arpv4.Make (Ethif) (Clock) (Time)
 
   (** IO operation errors *)
   type error = [

--- a/lib/ipv4.ml
+++ b/lib/ipv4.ml
@@ -75,7 +75,7 @@ module Make(Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = stru
       |ip when is_local t ip -> (* Local *)
         Lwt.catch
           (fun () -> Arpv4.query t.arp ip)
-          (function Not_found -> Lwt.fail (No_route_to_destination_address ip) | e -> Lwt.fail e)
+          (function (Arpv4.ARP_timeout _) -> Lwt.fail (No_route_to_destination_address ip) | e -> Lwt.fail e)
       |ip when Ipaddr.V4.is_multicast ip ->
         return (mac_of_multicast ip)
       |ip -> begin (* Gateway *)

--- a/lib/ipv4.mli
+++ b/lib/ipv4.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make ( N:V1_LWT.ETHIF ) : sig
+module Make ( N:V1_LWT.ETHIF ) ( C:V1.CLOCK ) ( T:V1_LWT.TIME ) : sig
   include V1_LWT.IPV4 with type ethif = N.t
   val connect : ethif -> [> `Ok of t | `Error of error ] Lwt.t
 end

--- a/unix/ipv4_unix.ml
+++ b/unix/ipv4_unix.ml
@@ -1,1 +1,1 @@
-include Ipv4.Make(Ethif_unix)
+include Ipv4.Make(Ethif_unix)(Clock)(OS.Time)


### PR DESCRIPTION
I find the code in `arpv4.ml` hard to follow and reason about.  See for example the discussion in #104.  In particular, it is hard to modify the code without introducing race conditions.

This patch tries to improve this state of affairs.  Along the way I incorporated @yomimono's patches in #104.  The first two commits contain the basic changes:  introduce a datatype `entry` to stop representing illegal states (right now one needs to be careful to keep `t.pending` and `t.cache` in sync which can easily lead to race conditions).  The rest of the commits just incorporate the changes of #104.

In order to timeout stale entries a single background thread is spawned on creation (see `tick`) which cleans up every 60s.

The only change that could potentially affect current users is that ARP lookups now timeout after `1.5s * 3`.  Before, ARP lookups would just linger forever if no answer was received.  The timeout values were taken from #104, where it refers to RFC 5227.

The mirage tool requires a small patch to work since the proposed ARPV4 (and hence IPV4) is a functor of `CLOCK` and `TIME`, so the generated code in `main.ml` needs to be modified accordingly.

I tested the patch with some of the examples of `mirage-skeleton` without encountering any problems.  Thoughts, ideas, comments ?

/cc @yomimono