### PR TITLE
Fix missing mirage-vnetif dep for --enable-tests

### DIFF
--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ tags: ["org:mirage"]
 
 build: [
   ["./configure" "--prefix" prefix
-      "--%{mirage-flow+alcotest:enable}%-tests"
+      "--%{mirage-flow+alcotest+mirage-vnetif:enable}%-tests"
       "--%{mirage-xen:enable}%-xen"
   ]
   [make]


### PR DESCRIPTION
Require mirage-vnetif to enable tests. Should fix #135 