### PR TITLE
Don't zero tx window when there are no ready segments

### DIFF
--- a/tcp/window.ml
+++ b/tcp/window.ml
@@ -134,10 +134,10 @@ let ack_seq t = t.ack_seq
 let ack_win t = t.ack_win
 
 let set_ack_serviced t v = t.ack_serviced <- v
-let set_ack_seq t s =
+let set_ack_seq_win t s w =
   MProf.Counter.increase count_ackd_segs (Sequence.(sub s t.ack_seq |> to_int));
-  t.ack_seq <- s
-let set_ack_win t w = t.ack_win <- w
+  t.ack_seq <- s;
+  t.ack_win <- w
 
 (* TODO: scale the window down so we can advertise it correctly with
    window scaling on the wire *)

--- a/tcp/window.mli
+++ b/tcp/window.mli
@@ -44,8 +44,7 @@ val ack_seq : t -> Sequence.t
 val ack_win : t -> int
 
 val set_ack_serviced : t -> bool -> unit
-val set_ack_seq : t -> Sequence.t -> unit
-val set_ack_win : t -> int -> unit
+val set_ack_seq_win : t -> Sequence.t -> int -> unit
 
 (* rx_wnd: number of bytes we are willing to accept *)
 val rx_wnd : t -> int32


### PR DESCRIPTION
 If there are no ready segments, leave the tx window alone. Before, we set it to size zero, preventing us from sending any further data. See: #140.

Not sure if this the correct fix, but after some light testing, it seems to help (no more hangs observed so far).