### PR TITLE
Use mirage-profile to implement Tcp.Log

### DIFF
--- a/tcp/log.ml
+++ b/tcp/log.ml
@@ -25,12 +25,17 @@ type t = {
 
 let c = ref 0
 
+let write pp =
+  let msg = Format.flush_str_formatter () in
+  print_endline msg;
+  MProf.Trace.label msg
+
 let f t =
   if t.enabled && t.stats then
     let stats = Stats.create () in
-    fun pp -> Format.printf ("Tcp.%s%a: %t\n%!") t.name Stats.pp stats pp
+    fun pp -> Format.kfprintf write Format.str_formatter ("Tcp.%s%a: %t") t.name Stats.pp stats pp
   else if t.enabled then
-    fun pp -> Format.printf ("Tcp.%s: %t\n%!") t.name pp
+    fun pp -> Format.kfprintf write Format.str_formatter ("Tcp.%s: %t") t.name pp
   else
     fun _pp -> ()
 

--- a/tcp/log.ml
+++ b/tcp/log.ml
@@ -32,8 +32,7 @@ let write pp =
 
 let f t =
   if t.enabled && t.stats then
-    let stats = Stats.create () in
-    fun pp -> Format.kfprintf write Format.str_formatter ("Tcp.%s%a: %t") t.name Stats.pp stats pp
+    fun pp -> Format.kfprintf write Format.str_formatter ("Tcp.%s%a: %t") t.name Stats.pp Stats.singleton pp
   else if t.enabled then
     fun pp -> Format.kfprintf write Format.str_formatter ("Tcp.%s: %t") t.name pp
   else

--- a/tcp/stats.mli
+++ b/tcp/stats.mli
@@ -22,12 +22,6 @@ type counter
 val value: counter -> int
 (** The counter value. [value t] is [{!incr} t] - [{!decrs} t].*)
 
-val incrs: counter -> int
-(** How many time the counter has been increased. *)
-
-val decrs: counter -> int
-(** How many time the counter has been decreased. *)
-
 type t = {
   tcp_flows   : counter;
   tcp_listens : counter;
@@ -53,7 +47,7 @@ val decr_connect: unit -> unit
 val incr_timer: unit -> unit
 val decr_timer: unit -> unit
 
-val create: unit -> t
+val singleton: t
 
 module Gc: sig
   (** Show GC stats *)

--- a/tcp/wire.ml
+++ b/tcp/wire.ml
@@ -87,7 +87,7 @@ module Make (Ip:V1_LWT.IP) = struct
           Ipaddr.pp_hum (Ip.to_uipaddr id.dest_ip)  id.dest_port
           rst syn fin psh sequence ack_number Options.pps options
           (Cstruct.lenv datav) (List.length datav) data_off options_len); *)
-    MProf.Counter.increase count_tcp_to_ip (Cstruct.lenv datav);
+    MProf.Counter.increase count_tcp_to_ip (Cstruct.lenv datav + (if syn then 1 else 0));
     Ip.writev ip frame datav
 
 end


### PR DESCRIPTION
- Whenever we log a message to the console, also record it in the trace (if any). This means that all TCP log messages also show up on their associated thread in the trace viewer, and can be searched for.

- Counters are now implemented using `MProf.Counter`, which means they appear as a graph overlaid on the trace.

I made a slight change to the `Stats` API: I replaced `create` with `singleton`, since that seemed to reflect better what it was doing (if you did want multiple counters, MProf supports that too, but these counts look global to me anyway).

To see the log messages, you still need to enable logging. e.g. I used:

    let () =
      let open Tcp in
      [Pcb.info; Pcb.debug; State.debug] |> List.iter (fun log ->
        Log.enable log;
        Log.set_stats log false
      )

(turning off stats just prevents the numbers appearing in the messages, which is unnecessary since changes to the counters are logged anyway)