### PR TITLE
RFC: If a TCP thread fails, call Lwt.async_exception_hook

### DIFF
--- a/tcp/pcb.ml
+++ b/tcp/pcb.ml
@@ -351,6 +351,10 @@ struct
     let fnth = fun _ -> th_frees := !th_frees + 1 in
     Gc.finalise fnpcb pcb;
     Gc.finalise fnth th;
+    Lwt.on_failure th (function
+      | Lwt.Canceled -> ()
+      | ex -> !Lwt.async_exception_hook ex
+    );
     Lwt.return (pcb, th, opts)
 
   let new_server_connection t params id pushf =


### PR DESCRIPTION
By default this will cause the unikernel to exit if the TCP code throws an exception. The application can override this by defining its own handler.

I think this is probably the correct behaviour, although it might break things due to pre-existing bugs (e.g. #153 - don't merge before fixing that!). At least, it should help us find other bugs!