### PR TITLE
Expose Ipv4.Routing.No_route_to_destination_address.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -8,8 +8,6 @@ bash -ex .travis-opam.sh
 export OPAMYES=1
 eval `opam config env`
 
-opam repo add mirage-dev https://github.com/mirage/mirage-dev.git
-
 git clone git://github.com/mirage/mirage-www
 cd mirage-www
 

--- a/lib/ipv4.mli
+++ b/lib/ipv4.mli
@@ -15,6 +15,11 @@
  *)
 
 module Make (N:V1_LWT.ETHIF) (A: V1_LWT.ARP) : sig
+  module Routing : sig
+    (* this exception can be thrown by `write` or `writev` when the destination
+       IP address's link-layer address can't be found by ARP *)
+    exception No_route_to_destination_address of Ipaddr.V4.t
+  end
   include V1_LWT.IPV4 with type ethif = N.t
   val connect : ethif -> A.t -> [> `Ok of t | `Error of error ] Lwt.t
 end


### PR DESCRIPTION
Calls to `Ipv4.write` and `Ipv4.writev` can fail if a link-level address for the destination IP can't be found via ARP; expose the exception generated in that case in `ipv4.mli` so users can match on it.