### PR TITLE
wrap ports for listeners at 65536

### DIFF
--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -77,10 +77,10 @@ struct
   let ipv4 { ipv4; _ } = ipv4
 
   let listen_udpv4 t ~port callback =
-    Hashtbl.replace t.udpv4_listeners (port mod 65536) callback
+    Hashtbl.replace t.udpv4_listeners port callback
 
   let listen_tcpv4 t ~port callback =
-    Hashtbl.replace t.tcpv4_listeners (port mod 65536) callback
+    Hashtbl.replace t.tcpv4_listeners port callback
 
   let configure_dhcp t info =
     Ipv4.set_ip t.ipv4 info.Dhcp.ip_addr

--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -63,8 +63,8 @@ struct
     ipv4  : Ipv4.t;
     udpv4 : Udpv4.t;
     tcpv4 : Tcpv4.t;
-    udpv4_listeners: (int, Udpv4.callback) Hashtbl.t;
-    tcpv4_listeners: (int, (Tcpv4.flow -> unit Lwt.t)) Hashtbl.t;
+    udpv4_listeners: (Cstruct.uint8, Udpv4.callback) Hashtbl.t;
+    tcpv4_listeners: (Cstruct.uint8, (Tcpv4.flow -> unit Lwt.t)) Hashtbl.t;
   }
 
   type error = [
@@ -77,10 +77,10 @@ struct
   let ipv4 { ipv4; _ } = ipv4
 
   let listen_udpv4 t ~port callback =
-    Hashtbl.replace t.udpv4_listeners port callback
+    Hashtbl.replace t.udpv4_listeners (port mod 65536) callback
 
   let listen_tcpv4 t ~port callback =
-    Hashtbl.replace t.tcpv4_listeners port callback
+    Hashtbl.replace t.tcpv4_listeners (port mod 65536) callback
 
   let configure_dhcp t info =
     Ipv4.set_ip t.ipv4 info.Dhcp.ip_addr


### PR DESCRIPTION
Previously, it was possible to register listeners for ports > 65535.
This had unexpected results, as serializing the requested port number
elsewhere in the stack would result in truncating the port number, but
reply packets would not match any known listener (since the registered
listener was at the requested port number).  Register the given port
number mod 65536 to avoid this even if the user submits an unreasonable
port number, for consistency with other parts of the stack.

Discovered via https://github.com/mirage/ocaml-dns/blob/master/mirage/dns_resolver_mirage.ml#L108 .