### PR TITLE
some state tests + fixes for closure conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 .*.swp
 setup.data
 setup.log
+test.native

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -15,9 +15,10 @@
  *)
 
 let suite = [
-  "arp"    , Test_arp.suite     ;
-  "connect", Test_connect.suite ;
-  "iperf"  , Test_iperf.suite   ;
+  "arp"            , Test_arp.suite         ;
+  "connect"        , Test_connect.suite     ;
+  "iperf"          , Test_iperf.suite       ;
+  "tcp_options"    , Test_tcp_options.suite ;
 ]
 
 let run test () =

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -19,6 +19,7 @@ let suite = [
   "connect"        , Test_connect.suite     ;
   "iperf"          , Test_iperf.suite       ;
   "tcp_options"    , Test_tcp_options.suite ;
+  "tcp_state"      , Test_tcp_state.suite   ;
 ]
 
 let run test () =

--- a/lib_test/test_tcp_options.ml
+++ b/lib_test/test_tcp_options.ml
@@ -1,0 +1,128 @@
+let test_unmarshal_bad_mss () =
+  let odd_sized_mss = Cstruct.create 3 in
+  Cstruct.set_uint8 odd_sized_mss 0 2;
+  Cstruct.set_uint8 odd_sized_mss 1 3;
+  Cstruct.set_uint8 odd_sized_mss 2 255;
+  OUnit.assert_raises (Tcp.Options.Bad_option "Invalid option 2 presented")
+    (fun () -> Tcp.Options.unmarshal odd_sized_mss);
+  Lwt.return_unit
+
+let test_unmarshal_bogus_length () =
+  let bogus = Cstruct.create (4*8-1) in
+  Cstruct.memset bogus 0;
+  Cstruct.blit_from_string "\x6e\x73\x73\x68\x2e\x63\x6f\x6d" 0 bogus 0 8;
+  (* some unknown option (0x6e) with claimed length 0x73, longer than the buffer *)
+  OUnit.assert_raises (Tcp.Options.Bad_option "Invalid option 110 presented")
+    (fun () -> Tcp.Options.unmarshal bogus);
+  Lwt.return_unit
+
+let test_unmarshal_zero_length () =
+  let bogus = Cstruct.create 10 in
+  Cstruct.memset bogus 1; (* noops *)
+  Cstruct.set_uint8 bogus 0 64; (* arbitrary unknown option-kind *)
+  Cstruct.set_uint8 bogus 1 0;
+  OUnit.assert_raises (Tcp.Options.Bad_option "Invalid option 64 presented")
+    (fun () -> Tcp.Options.unmarshal bogus);
+  Lwt.return_unit
+
+let test_unmarshal_simple_options () =
+  (* empty buffer should give empty list *)
+  OUnit.assert_equal [] (Tcp.Options.unmarshal (Cstruct.create 0));
+
+  (* buffer with just eof should give empty list *)
+  let just_eof = Cstruct.create 1 in
+  Cstruct.set_uint8 just_eof 0 0;
+  OUnit.assert_equal [] (Tcp.Options.unmarshal just_eof);
+
+  (* buffer with single noop should give a list with 1 noop *)
+  let just_noop = Cstruct.create 1 in
+  Cstruct.set_uint8 just_noop 0 1;
+  OUnit.assert_equal [ Tcp.Options.Noop ] (Tcp.Options.unmarshal just_noop); 
+
+  (* buffer with valid, but unknown, option should be correctly communicated *)
+  let unknown = Cstruct.create 10 in
+  let data = "hi mom!!" in
+  let kind = 18 in (* TODO: more canonically unknown option-kind *)
+  Cstruct.blit_from_string data 0 unknown 2 (String.length data);
+  Cstruct.set_uint8 unknown 0 kind;
+  Cstruct.set_uint8 unknown 1 (Cstruct.len unknown);
+  OUnit.assert_equal (Tcp.Options.unmarshal unknown) [Tcp.Options.Unknown (kind, data) ];
+  Lwt.return_unit
+
+let test_unmarshal_stops_at_eof () =
+  let buf = Cstruct.create 14 in
+  let ts1 = (Int32.of_int 0xabad1dea) in
+  let ts2 = (Int32.of_int 0xc0ffee33) in
+  Cstruct.memset buf 0;
+  Cstruct.set_uint8 buf 0 4; (* sack_ok *)
+  Cstruct.set_uint8 buf 1 2; (* length of two *)
+  Cstruct.set_uint8 buf 2 1; (* noop *)
+  Cstruct.set_uint8 buf 3 0; (* eof *)
+  Cstruct.set_uint8 buf 4 8; (* timestamp *)
+  Cstruct.set_uint8 buf 5 10; (* timestamps are 2 4-byte times *)
+  Cstruct.BE.set_uint32 buf 6 ts1;
+  Cstruct.BE.set_uint32 buf 10 ts2;
+  (* correct parsing will ignore options from after eof, so we shouldn't see
+     timestamp or noop *)
+  let result = Tcp.Options.unmarshal buf in
+  OUnit.assert_equal ~msg:"SACK_ok missing" ~printer:string_of_bool
+    true (List.mem Tcp.Options.SACK_ok result);
+  OUnit.assert_equal ~msg: "noop missing" ~printer:string_of_bool
+    true (List.mem Tcp.Options.Noop result);
+  OUnit.assert_equal ~msg:"timestamp present" ~printer:string_of_bool
+    false (List.mem (Tcp.Options.Timestamp (ts1, ts2)) result);
+  Lwt.return_unit
+
+let test_unmarshal_ok_options () =
+  let buf = Cstruct.create 8 in
+  Cstruct.memset buf 0;
+  let opts = [ Tcp.Options.MSS 536; Tcp.Options.SACK_ok; Tcp.Options.Noop;
+               Tcp.Options.Noop ] in
+  let printer l =
+    let buf = Buffer.create 10 in
+    Buffer.clear buf;
+    Tcp.Options.pps (Format.formatter_of_buffer buf) l;
+    Buffer.to_bytes buf
+  in
+  let marshalled = Tcp.Options.marshal buf opts in
+  OUnit.assert_equal ~printer:string_of_int marshalled 8;
+  (* order is reversed by the unmarshaller, which is fine but we need to
+     account for that when making equality assertions *)
+  OUnit.assert_equal ~printer (List.rev (Tcp.Options.unmarshal buf)) opts;
+  Lwt.return_unit
+
+let test_unmarshal_random_data () =
+  let random = Cstruct.create 64 in
+  let iterations = 100 in
+  Random.self_init ();
+  let set_random pos =
+    let num = Random.int32 Int32.max_int in
+    Cstruct.BE.set_uint32 random pos num;
+  in
+  let rec check = function
+    | n when n <= 0 -> Lwt.return_unit
+    | n ->
+      List.iter set_random [0;4;8;12;16;20;24;28;32;36;40;44;48;52;56;60];
+      Cstruct.hexdump random;
+      (* acceptable outcomes: some list of options or the expected exception *)
+      try
+        let l = Tcp.Options.unmarshal random in
+        Tcp.Options.pps Format.std_formatter l;
+        (* a really basic truth: the longest list we can have is 64 noops *)
+        OUnit.assert_equal true (List.length l < 65);
+        check (n - 1)
+      with
+      | Tcp.Options.Bad_option _ -> check (n - 1)
+  in
+  check iterations
+
+
+let suite = [
+  "unmarshal broken mss", `Quick, test_unmarshal_bad_mss;
+  "unmarshal option with bogus length", `Quick, test_unmarshal_bogus_length;
+  "unmarshal option with zero length", `Quick, test_unmarshal_zero_length;
+  "unmarshal simple cases", `Quick, test_unmarshal_simple_options;
+  "unmarshal stops at eof", `Quick, test_unmarshal_stops_at_eof;
+  "unmarshal non-broken tcp options", `Quick, test_unmarshal_ok_options;
+  "unmarshalling random data returns", `Quick, test_unmarshal_random_data;
+]

--- a/lib_test/test_tcp_options.ml
+++ b/lib_test/test_tcp_options.ml
@@ -80,17 +80,11 @@ let test_unmarshal_ok_options () =
   Cstruct.memset buf 0;
   let opts = [ Tcp.Options.MSS 536; Tcp.Options.SACK_ok; Tcp.Options.Noop;
                Tcp.Options.Noop ] in
-  let printer l =
-    let buf = Buffer.create 10 in
-    Buffer.clear buf;
-    Tcp.Options.pps (Format.formatter_of_buffer buf) l;
-    Buffer.to_bytes buf
-  in
   let marshalled = Tcp.Options.marshal buf opts in
   check marshalled 8;
   (* order is reversed by the unmarshaller, which is fine but we need to
      account for that when making equality assertions *)
-  OUnit.assert_equal ~printer (List.rev (Tcp.Options.unmarshal buf)) opts;
+  OUnit.assert_equal (List.rev (Tcp.Options.unmarshal buf)) opts;
   Lwt.return_unit
 
 let test_unmarshal_random_data () =

--- a/lib_test/test_tcp_state.ml
+++ b/lib_test/test_tcp_state.ml
@@ -1,0 +1,319 @@
+module No_time : sig
+  include V1_LWT.TIME
+end = struct
+  type 'a io = 'a Lwt.t
+  let sleep _ = Lwt.return_unit
+end
+module Tricky_time : sig
+  include V1_LWT.TIME
+  val wake : unit -> unit
+end = struct
+  type 'a io = 'a Lwt.t
+  let u = ref None
+  let rec sleep time =
+    let open Lwt.Infix in
+    let (sleeper, wakener) = Lwt.wait () in
+    u := Some wakener;
+    sleeper >>= fun _ -> Lwt.return_unit
+  let wake () =
+    match !u with
+    | Some wakener -> Lwt.wakeup wakener ()
+    | None -> ()
+end
+
+module Timeless_state = Tcp.State.Make(No_time)
+module Tricky_state = Tcp.State.Make(Tricky_time)
+open Tcp.State
+
+let get_closed () = start ~on_close:(fun _ -> ())
+let seq n = Tcp.Sequence.of_int n
+let random_item l =
+  Random.self_init ();
+  let i = Random.int (List.length l) in
+  List.nth l i
+
+(* disregarding sequence numbers, is this a valid transition? *)
+let valid left right =
+  match left, right with
+  | Closed, Syn_sent _ -> true
+  | Closed, Listen -> true
+  | Syn_sent _, Closed -> true
+  | Syn_sent _, Syn_rcvd _-> true
+  | Syn_sent _, Established -> true
+  | Syn_rcvd _, Listen -> true
+  | Syn_rcvd _, Established -> true
+  | Syn_rcvd _, Fin_wait_1 _ -> true
+  | Established, Fin_wait_1 _ -> true
+  | Established, Close_wait -> true
+  | Fin_wait_1 _, Closing _ -> true
+  | Fin_wait_1 _, Time_wait -> true
+  | Fin_wait_1 _, Fin_wait_2 -> true
+  | Fin_wait_2 , Time_wait -> true
+  | Closing _, Time_wait -> true
+  | Time_wait, Closed -> true
+  | Close_wait, Last_ack _ -> true
+  | Last_ack _, Closed -> true
+  | left, right when left = right -> true (* maintaining state is always valid *)
+  | _, _ -> false
+
+(* given a sequence number, generate a list of possible actions (with that
+   sequence number if sequence numbers are applicable) *)
+let actions s = [
+  Passive_open
+; Recv_rst
+; Recv_synack s
+; Recv_ack s
+; Recv_fin
+; Send_syn s
+; Send_synack s
+; Send_rst
+; Send_fin s
+; Timeout
+]
+
+let states s = [
+    Closed
+  ; Listen
+  ; Syn_rcvd s
+  ; Syn_sent s
+  ; Established
+  ; Close_wait
+  ; Last_ack s
+  ; Fin_wait_1 s
+  ; Fin_wait_2
+  ; Closing s
+  ; Time_wait
+]
+
+let state_is t s =
+  let pp_diff formatter (expected, actual) =
+    Format.pp_print_string formatter "expected state:";
+    pp_tcpstate formatter expected;
+    Format.print_newline ();
+    Format.pp_print_string formatter "actual state:";
+    pp_tcpstate formatter actual
+  in
+  let actual_state = state t in
+  OUnit.assert_equal ~pp_diff s actual_state
+
+let rec get_to = function
+  | Closed -> get_closed ()
+  | Listen ->
+    let t = get_closed () in
+    Timeless_state.tick t Passive_open;
+    state_is t Listen;
+    t
+  | Syn_sent s ->
+    let t = get_closed () in
+    Timeless_state.tick t (Send_syn s);
+    state_is t (Syn_sent s);
+    t
+  | Syn_rcvd s ->
+    let t = get_closed () in
+    Timeless_state.tick t Passive_open;
+    Timeless_state.tick t (Send_synack s);
+    state_is t (Syn_rcvd s);
+    t
+  | Established ->
+    let s = 0xabad1dea in
+    let sa = s + 1 in
+    let t = get_closed () in
+    Timeless_state.tick t (Send_syn (seq s));
+    Timeless_state.tick t (Recv_synack (seq sa));
+    state_is t Established;
+    t
+  | Fin_wait_1 s ->
+    let t = get_to Established in
+    Tricky_state.tick t (Send_fin s);
+    state_is t (Fin_wait_1 s);
+    t
+  | Fin_wait_2 ->
+    let t = get_to (Fin_wait_1 (seq 0xabad1dea)) in
+    Timeless_state.tick t (Recv_ack (seq (0xabad1dea + 1)));
+    state_is t Fin_wait_2;
+    t
+  | Closing s ->
+    let t = get_to (Fin_wait_1 s) in
+    Tricky_state.tick t Recv_fin;
+    state_is t (Closing s);
+    t
+  | Time_wait ->
+    let t = get_to Fin_wait_2 in
+    Tricky_state.tick t Recv_fin;
+    state_is t Time_wait;
+    t
+  | Close_wait ->
+    let t = get_to Established in
+    Tricky_state.tick t Recv_fin;
+    state_is t Close_wait;
+    t
+  | Last_ack s ->
+    let t = get_to Close_wait in
+    Tricky_state.tick t (Send_fin s);
+    state_is t (Last_ack s);
+    t
+
+let get_to_states () =
+  let _ = List.map get_to (states (seq 0xbadd00d5)) in
+  Lwt.return_unit
+
+let initial_listen () =
+  let t = start ~on_close:(fun _ -> ()) in
+  state_is t Closed;
+  Lwt.return_unit
+
+let stay_closed () =
+  (* Closed connections ignore all but outgoing SYN *)
+  let still_closed t = function
+    | Passive_open | Send_syn _ -> ()
+    | action ->
+      Timeless_state.tick t action;
+      state_is t Closed
+  in
+  let closed = get_closed () in
+  List.iter (still_closed closed) (actions (seq 0xabad1dea));
+  Lwt.return_unit
+
+let initial_open () =
+  let t = get_closed () in
+  Timeless_state.tick t Passive_open;
+  state_is t Listen;
+  let t = get_closed () in
+  let seq_no = 0xabad1dea in
+  Timeless_state.tick t (Send_syn (seq seq_no));
+  state_is t (Syn_sent (seq seq_no));
+  Lwt.return_unit
+
+let finwait2_resolves_normally () =
+  let t = get_closed () in
+  Tricky_state.tick t (Send_syn (seq 1));
+  Tricky_state.tick t (Recv_synack (seq 2));
+  Tricky_state.tick t (Send_fin (seq 3));
+  state_is t (Fin_wait_1 (seq 3));
+  Tricky_state.tick t (Recv_ack (seq 4));
+  (* finwait2timer should have launched there *)
+  state_is t Fin_wait_2;
+  Tricky_time.wake ();
+  (* finwait2timer should now have finished *)
+  state_is t Closed;
+  Lwt.return_unit
+
+let finwait2_resolves_multiple_acks () =
+  let t = get_closed () in
+  Tricky_state.tick t (Send_syn (seq 1));
+  Tricky_state.tick t (Recv_synack (seq 2));
+  (* should be Established now *)
+  state_is t Established;
+  Tricky_state.tick t (Send_fin (seq 3));
+  state_is t (Fin_wait_1 (seq 3));
+  Tricky_state.tick t (Recv_ack (seq 4));
+  (* finwait2timer should have launched there *)
+  (* because we're using Tricky_state, we can fire as many acks as we like and
+     observe the behavior until we call Tricky_timer.wake *)
+  state_is t Fin_wait_2;
+  Tricky_state.tick t (Recv_ack (seq 4));
+  state_is t Fin_wait_2;
+  Tricky_time.wake ();
+  (* finwait2timer should now have finished *)
+  state_is t Closed;
+  Lwt.return_unit
+
+let rst_closes t =
+  Timeless_state.tick t Recv_rst;
+  state_is t Closed
+
+let rst_listen () =
+  let t = get_to Listen in
+  Timeless_state.tick t (Recv_rst);
+  state_is t Listen;
+  Lwt.return_unit
+
+let rst_syn_rcvd () =
+  let t = get_to (Syn_rcvd (seq 2)) in
+  Timeless_state.tick t (Recv_rst);
+  state_is t Listen;
+  Lwt.return_unit
+
+let rst_syn_sent () =
+  let t = get_to (Syn_sent (seq 1)) in
+  rst_closes t;
+  Lwt.return_unit
+
+
+let rst_established () =
+  let t = get_to Established in
+  rst_closes t;
+  Lwt.return_unit
+
+let rst_sent_fin () =
+  let t = get_to Established in
+  (* data exchange in ESTABLISHED happens for a while *)
+  Timeless_state.tick t (Send_fin (seq 100));
+  rst_closes t;
+  Lwt.return_unit
+
+let rst_fin_wait_2 () =
+  let t = get_to Fin_wait_2 in
+  (* get an RST before time-wait expires *)
+  Tricky_state.tick t Recv_rst;
+  state_is t Closed;
+  Lwt.return_unit
+
+let rst_rcvd_fin () =
+  let t = get_to Established  in
+  (* other side closes *)
+  Timeless_state.tick t Recv_fin;
+  (* normally we wouldn't close until we get action Send_fin *)
+  rst_closes t;
+  Lwt.return_unit
+
+let rst_teardown =
+  (* Quoth RFC 793,
+       Reset Processing
+
+       In all states except SYN-SENT, all reset (RST) segments are validated
+       by checking their SEQ-fields.  A reset is valid if its sequence number
+       is in the window.  In the SYN-SENT state (a RST received in response
+  to an initial SYN), the RST is acceptable if the ACK field
+       acknowledges the SYN.
+
+       The receiver of a RST first validates it, then changes state.  If the
+       receiver was in the LISTEN state, it ignores it.  If the receiver was
+       in SYN-RECEIVED state and had previously been in the LISTEN state,
+  then the receiver returns to the LISTEN state, otherwise the receiver
+       aborts the connection and goes to the CLOSED state.  If the receiver
+       was in any other state, it aborts the connection and advises the user
+       and goes to the CLOSED state.
+  *)
+
+  (* Clearly we can't do the right thing because we don't support
+     reflecting the sequence number of the RST in the types currently. *)
+  [ "RSTs do not tear down connections in LISTEN", `Quick, rst_listen;
+    "RSTs tear down connections in SYN_SENT", `Quick, rst_syn_sent;
+    "RSTs send connections in SYN_RCVD to LISTEN", `Quick, rst_syn_rcvd;
+    "RSTs tear down connections in ESTABLISHED", `Quick, rst_established;
+    "RSTs tear down connections when a FIN has been sent", `Quick, rst_sent_fin;
+    "RSTs tear down connections in FIN_WAIT_2", `Quick, rst_fin_wait_2;
+    "RSTs tear down connections when a FIN has been received", `Quick, rst_rcvd_fin;
+  ]
+
+let out_of_sequence_ack () =
+  let t = get_closed () in
+  Timeless_state.tick t Passive_open;
+  Timeless_state.tick t (Send_synack (seq 1));  (* this must be our seq #? *)
+  state_is t (Syn_rcvd (seq 1));
+  Timeless_state.tick t (Recv_ack (seq 504803));
+  state_is t (Syn_rcvd (seq 1));
+  Timeless_state.tick t (Recv_ack (seq 2));
+  state_is t Established;
+  Lwt.return_unit
+
+let suite = List.append [
+  "states are reachable as expected", `Quick, get_to_states;
+  "initial state is Closed", `Quick, initial_listen;
+  "valid transitions from Closed occur", `Quick, initial_open;
+  "invalid transitions from Closed are ignored", `Quick, stay_closed;
+  "connections in fin_wait_2 resolve with one ACK", `Quick, finwait2_resolves_normally;
+  "connections in fin_wait_2 resolve even with multiple ACKs", `Quick, finwait2_resolves_multiple_acks;
+  "out-of-sequence ACKs don't complete 3-way handshake", `Quick, out_of_sequence_ack;
+] rst_teardown

--- a/opam
+++ b/opam
@@ -29,7 +29,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "tcpip"]
 depends: [
   "ocamlfind" {build}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.6.0"}
   "channel"
   "mirage-types" {>= "2.6.0"}
   "mirage-unix" {>= "1.1.0"}

--- a/tcp/options.ml
+++ b/tcp/options.ml
@@ -131,10 +131,11 @@ let write_iter buf =
     Cstruct.BE.set_uint32 buf 2 tsval;
     Cstruct.BE.set_uint32 buf 6 tsecr;
     10
-  | Unknown (kind,contents) ->
-    let tlen = String.length contents in
+  | Unknown (kind, contents) ->
+    let content_len = String.length contents in
+    let tlen = content_len + 2 in
     set_tlen kind tlen;
-    Cstruct.blit_from_string contents 0 buf 0 tlen;
+    Cstruct.blit_from_string contents 0 buf 2 content_len;
     tlen
 
 let marshal buf ts =

--- a/tcp/pcb.ml
+++ b/tcp/pcb.ml
@@ -323,7 +323,7 @@ struct
     let tx_wnd_update = MProf.Trace.named_mvar_empty "tx_wnd_update" in
     (* Set up transmit and receive queues *)
     let on_close () = clearpcb t id tx_isn in
-    let state = State.t ~on_close in
+    let state = State.start ~on_close in
     let txq, _tx_t =
       TXS.create ~xmit:(Tx.xmit_pcb t.ip id) ~wnd ~state ~rx_ack ~tx_ack ~tx_wnd_update
     in

--- a/tcp/segment.mli
+++ b/tcp/segment.mli
@@ -60,7 +60,7 @@ module Rx (T:V1_LWT.TIME) : sig
 end
 
 type tx_flags = No_flags | Syn | Fin | Rst | Psh
-(** Either Syn/Fin/Rst allowed, but not combinations *)
+(** At most one of Syn/Fin/Psh/Rst allowed, but not combinations *)
 
 (** Pre-transmission queue *)
 module Tx (Time:V1_LWT.TIME)(Clock:V1.CLOCK) : sig

--- a/tcp/state.ml
+++ b/tcp/state.ml
@@ -41,7 +41,7 @@ type tcpstate =
   | Close_wait
   | Last_ack of Sequence.t
   | Fin_wait_1 of Sequence.t
-  | Fin_wait_2 of int
+  | Fin_wait_2
   | Closing of Sequence.t
   | Time_wait
   | Reset
@@ -80,7 +80,7 @@ let pp_tcpstate fmt = function
   | Close_wait   -> Log.ps fmt "Close_wait"
   | Last_ack x   -> Log.pf fmt "Last_ack(%a)" Sequence.pp x
   | Fin_wait_1 x -> Log.pf fmt "Fin_wait_1(%a)" Sequence.pp x
-  | Fin_wait_2 i -> Log.pf fmt "Fin_wait_2(%d)" i
+  | Fin_wait_2   -> Log.pf fmt "Fin_wait_2"
   | Closing x    -> Log.pf fmt "Closing(%a)" Sequence.pp x
   | Time_wait    -> Log.ps fmt "Time_wait"
   | Reset        -> Log.ps fmt "Reset"
@@ -92,19 +92,15 @@ module Make(Time:V1_LWT.TIME) = struct
   let fin_wait_2_time = (* 60. *) 10.
   let time_wait_time = (* 30. *) 2.
 
-  let rec finwait2timer t count timeout =
+  let rec finwait2timer t timeout =
     Log.f debug (fun fmt -> Log.pf fmt "finwait2timer %.02f" timeout);
     Time.sleep timeout >>= fun () ->
     match t.state with
-    | Fin_wait_2 i ->
+    | Fin_wait_2 ->
       Log.s debug "finwait2timer: Fin_wait_2";
-      if i = count then begin
-        t.state <- Closed;
-        t.on_close ();
-        Lwt.return_unit
-      end else begin
-        finwait2timer t i timeout
-      end
+      t.state <- Closed;
+      t.on_close ();
+      Lwt.return_unit
     | s ->
       Log.f debug (fun fmt -> Log.pf fmt "finwait2timer: %a" pp_tcpstate s);
       Lwt.return_unit
@@ -127,19 +123,25 @@ module Make(Time:V1_LWT.TIME) = struct
       | Syn_rcvd _, Timeout -> t.on_close (); Closed
       | Syn_rcvd _, Recv_rst -> Closed
       | Syn_sent _, Timeout -> t.on_close (); Closed
-      | Syn_sent a, Recv_synack b-> if diffone b a then Established else Syn_sent a
       | Syn_rcvd a, Recv_ack b -> if diffone b a then Established else Syn_rcvd a
+      | Syn_sent a, Recv_synack b -> if diffone b a then Established else Syn_sent a
+      | Syn_sent a, Recv_rstack b ->
+        if diffone b a then begin t.on_close (); Closed end
+        else Syn_sent a
       | Established, Recv_ack _ -> Established
       | Established, Send_fin a -> Fin_wait_1 a
       | Established, Recv_fin -> Close_wait
       | Established, Timeout ->  t.on_close (); Closed
       | Established, Recv_rst -> t.on_close (); Reset
       | Fin_wait_1 a, Recv_ack b ->
-        if diffone b a then
-          let count = 0 in
-          Lwt.async (fun () -> finwait2timer t count fin_wait_2_time);
-          Fin_wait_2 count
-        else
+        if diffone b a then begin
+          Lwt.async (fun () -> finwait2timer t fin_wait_2_time);
+          Fin_wait_2
+            (* so the first time we enter fin_wait_2, we set the count to 0 and
+               spawn a waiting thread; the waiting thread only closes the
+               connection if the state still matches the number.  So if we keep
+               receiving ACKs, won't we never close? That seems incorrect. *)
+        end else
           Fin_wait_1 a
       | Fin_wait_1 a, Recv_fin -> Closing a
       | Fin_wait_1 _, Timeout -> t.on_close (); Closed
@@ -158,7 +160,7 @@ module Make(Time:V1_LWT.TIME) = struct
       | Close_wait,  Recv_rst -> t.on_close (); Reset
       | Last_ack a, Recv_ack b -> if diffone b a then (t.on_close (); Closed) else Last_ack a
       | Last_ack _, Timeout -> t.on_close (); Closed
-      | Last_ack _, Recv_rst -> t.on_close (); Reset
+      | _, Recv_rst _ -> t.on_close (); Closed
       | x, _ -> x
     in
     let old_state = t.state in

--- a/tcp/state.ml
+++ b/tcp/state.ml
@@ -53,7 +53,7 @@ type t = {
   mutable state: tcpstate;
 }
 
-let t ~on_close =
+let start ~on_close =
   { on_close; state=Closed }
 
 let state t = t.state

--- a/tcp/state.mli
+++ b/tcp/state.mli
@@ -40,7 +40,7 @@ type tcpstate =
   | Close_wait
   | Last_ack of Sequence.t
   | Fin_wait_1 of Sequence.t
-  | Fin_wait_2 of int
+  | Fin_wait_2
   | Closing of Sequence.t
   | Time_wait
   | Reset
@@ -61,13 +61,11 @@ module Make(Time : V1_LWT.TIME) : sig
   (* when in state fin_wait_2, use this as a timeout parameter  *)
   val time_wait_time : float
     (* when in state Time_wait, wait this long before transitioning to Closed *)
-  val finwait2timer : t -> int -> float -> unit Lwt.t
-(* [finwait2timer t count timeout]
-    (the actual
-       logic is that we wait this long, then check the state; if it's
-       Fin_wait_2 n, and n == the number of times we've received an ack when
-       we've been in Fin_wait_2, close?
-       Otherwise, call finwait2 again? *)
+  val finwait2timer : t -> float -> unit Lwt.t
+(* [finwait2timer t timeout] waits for the given amount of time, then if the
+   state is still Fin_wait_2, sets the state to closed and calls on_close.  If
+   the state is other than Fin_wait_2, it is assumed that whatever set the state
+   to something else has handled the closure and the state is not changed. *)
   val timewait : t -> float -> unit Lwt.t
 (* [timewait t time] waits for time, then sets the state to closed and calls
    on_close *)

--- a/tcp/state.mli
+++ b/tcp/state.mli
@@ -19,6 +19,7 @@ val debug: Log.t
 type action =
   | Passive_open
   | Recv_rst
+  | Recv_rstack of Sequence.t (* ACK number *)
   | Recv_synack of Sequence.t
   | Recv_ack of Sequence.t
   | Recv_fin
@@ -43,7 +44,6 @@ type tcpstate =
   | Fin_wait_2
   | Closing of Sequence.t
   | Time_wait
-  | Reset
 
 val pp_tcpstate : Format.formatter -> tcpstate -> unit
 


### PR DESCRIPTION
PR is based on #174 rather than master, so the changeset is smaller than it initially appears.

Resolve a couple of TODOs:
* check ACK numbers when processing RSTs received after sending an initial SYN
* make `Tcp.State.t` abstract

In addition, a few more changes:
* replace the `Reset` state with `Closed`
* fix a bug where timers for `Fin_wait_2` would never resolve if multiple ACKs to a sent FIN were received
* process RSTs only when the sequence number exactly matches the left edge of the receive window (see [RFC 5961](https://tools.ietf.org/html/rfc5961))

And some added tests:
* a bunch of tests for `tcp/state.ml`.  Note that logic around checking seq/ack numbers is scattered between different modules in `tcp/`, so these tests can't be complete by targeting only this module.
* `Tcp.create_connection` reports failure immediately and correctly when the initial SYN receives an RST/ACK in response