### PR TITLE
Remove bogus warning about ignored socket config

### DIFF
--- a/unix/tcpip_stack_socket.ml
+++ b/unix/tcpip_stack_socket.ml
@@ -69,6 +69,7 @@ module Make(Console:V1_LWT.CONSOLE) = struct
   let configure t addrs =
     match addrs with
     | [] -> return_unit
+    | [any] when Ipaddr.V4.(compare any) any = 0 -> return_unit
     | _ -> Console.log_s t.c "Manager: socket config currently ignored (TODO)"
 
   let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p


### PR DESCRIPTION
If the client requests binding to V4.any then it reports:

    Manager: socket config currently ignored (TODO)

and then binds to it anyway. Skip the warning in this case.