### PR TITLE
Minor IPv4 API improvements

### DIFF
--- a/lib/ipv4.ml
+++ b/lib/ipv4.ml
@@ -224,16 +224,9 @@ module Make(Ethif: V1_LWT.ETHIF) (Arpv4 : V1_LWT.ARP) = struct
 
   let get_ip_gateways { gateways; _ } = gateways
 
-  let checksum =
-    let pbuf = Io_page.to_cstruct (Io_page.get 1) in
-    let pbuf = Cstruct.set_len pbuf 4 in
-    Cstruct.set_uint8 pbuf 0 0;
-    fun frame bufs ->
-      let frame = Cstruct.shift frame Wire_structs.sizeof_ethernet in
-      Cstruct.set_uint8 pbuf 1 (Wire_structs.Ipv4_wire.get_ipv4_proto frame);
-      Cstruct.BE.set_uint16 pbuf 2 (Cstruct.lenv bufs);
-      let src_dst = Cstruct.sub frame 12 (2 * 4) in
-      Tcpip_checksum.ones_complement_list (src_dst :: pbuf :: bufs)
+  let checksum frame =
+    let packet = Cstruct.shift frame Wire_structs.sizeof_ethernet in
+    Wire_structs.Ipv4_wire.checksum packet
 
   let get_source t ~dst:_ =
     t.ip

--- a/lib/tcpip_stack_direct.mli
+++ b/lib/tcpip_stack_direct.mli
@@ -38,6 +38,7 @@ module Make
      and type udpv4   = Udpv4.t
      and type tcpv4   = Tcpv4.t
      and type ipv4    = Ipv4.t
+     and module IPV4 = Ipv4
      and module TCPV4 = Tcpv4
      and module UDPV4 = Udpv4
   val connect : (console, netif, mode) V1_LWT.stackv4_config ->

--- a/lib/wire_structs.ml
+++ b/lib/wire_structs.ml
@@ -61,6 +61,19 @@ module Ipv4_wire = struct
     | `ICMP   -> 1
     | `TCP    -> 6
     | `UDP    -> 17
+
+  (* [checksum packet bufs] computes the IP checksum of [bufs]
+      computing the pseudo-header from the actual header [packet]
+      (which does NOT include the link-layer part). *)
+  let checksum =
+    let pbuf = Io_page.to_cstruct (Io_page.get 1) in
+    let pbuf = Cstruct.set_len pbuf 4 in
+    Cstruct.set_uint8 pbuf 0 0;
+    fun packet bufs ->
+      Cstruct.set_uint8 pbuf 1 (get_ipv4_proto packet);
+      Cstruct.BE.set_uint16 pbuf 2 (Cstruct.lenv bufs);
+      let src_dst = Cstruct.sub packet 12 (2 * 4) in
+      Tcpip_checksum.ones_complement_list (src_dst :: pbuf :: bufs)
 end
 
 module Tcp_wire = struct


### PR DESCRIPTION
- Expose that `module IPV4 = Ipv4` in direct stack functor, as we do for the other modules.
- Expose `Wire_structs.Ipv4_wire.checksum` (avoids work-arounds like https://github.com/yomimono/mirage-nat/blob/b5b8e973864650d2c0b5d4d2149cd715851b3818/lib/nat_rewrite.mli#L65). I made it take only the IP-level data, since it's easier to skip the ethernet frame if you have it than to add a fake one if you don't.