### PR TITLE
Tcpv{4,6}_socket: transform EPIPE into Eof

### DIFF
--- a/unix/tcpv4_socket.ml
+++ b/unix/tcpv4_socket.ml
@@ -87,11 +87,16 @@ let read fd =
     (fun exn -> return (`Error (`Unknown (Printexc.to_string exn))))
 
 let rec write fd buf =
-  Lwt_cstruct.write fd buf
-  >>= function
-  | n when n = Cstruct.len buf -> return (`Ok ())
-  | 0 -> return `Eof
-  | n -> write fd (Cstruct.sub buf n (Cstruct.len buf - n))
+  Lwt.catch
+    (fun () ->
+      Lwt_cstruct.write fd buf
+      >>= function
+      | n when n = Cstruct.len buf -> return (`Ok ())
+      | 0 -> return `Eof
+      | n -> write fd (Cstruct.sub buf n (Cstruct.len buf - n))
+    ) (function
+      | Unix.Unix_error(Unix.EPIPE, _, _) -> return `Eof
+      | e -> Lwt.fail e)
 
 let writev fd bufs =
   Lwt_list.fold_left_s


### PR DESCRIPTION
The V1.mli describes the result of `FLOW.write`:

> The result [\`Ok ()] indicates success, [\`Eof] indicates
> that the connection is now closed and [\`Error]
> indicates some other error.

In Unix if a peer closes its socket then `write` will fail with
`Unix_error(Unix.EPIPE, _, _)`, not a return value of 0 (unlike
`read`). Before this patch if a peer closes its connection then
the failure bubbles up to the consumer of the `FLOW` interface
who knows nothing about Unix and will typically fail outright
with an error like:

```
Fatal error: exception Unix.Unix_error(Unix.EPIPE, "write", "")
Raised by primitive operation at file "src/unix/lwt_bytes.ml", line 144, characters 43-86
Called from file "src/unix/lwt_unix.ml", line 549, characters 17-28
```

After this patch the consumer of the `FLOW` interface will
receive an `Eof` indicating that the connection is now closed.

Signed-off-by: David Scott <dave.scott@docker.com>