### PR TITLE
Add LICENSE, update opam file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+Copyright (c) Anil Madhavapeddy <anil@recoil.org>
+Copyright (c) Balraj Singh <balrajsingh@ieee.org>
+Copyright (c) Citrix Inc
+Copyright (c) David Scott <dave@recoil.org>
+Copyright (c) Docker Inc
+Copyright (c) Drup <drupyog@zoho.com>
+Copyright (c) Gabor Pali <pali.gabor@gmail.com>
+Copyright (c) Hannes Mehnert <hannes@mehnert.org>
+Copyright (c) Haris Rotsos <cr409@cam.ac.uk>
+Copyright (c) Kia <sadieperkins@riseup.net>
+Copyright (c) Luke Dunstan <LukeDunstan81@gmail.com>
+Copyright (c) Magnus Skjegstad <magnus@skjegstad.com>
+Copyright (c) Mindy Preston <meetup@yomimono.org>
+Copyright (c) Nicolas Ojeda Bar <n.oje.bar@gmail.com>
+Copyright (c) Pablo Polvorin <ppolvorin@process-one.net>
+Copyright (c) Richard Mortier <mort@cantab.net>
+Copyright (c) Thomas Gazagnaire <thomas@gazagnaire.org>
+Copyright (c) Thomas Leonard <talex5@gmail.com>
+Copyright (c) Tim Cuthbertson <tim@gfxmonk.net>
+Copyright (c) Vincent Bernardoff <vb@luminar.eu.org>
+Copyright (c) lnmx <len@lnmx.org>
+Copyright (c) pqwy <david@numm.org> 
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS l SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/opam
+++ b/opam
@@ -13,7 +13,18 @@ authors: [
   "Magnus Skjegstad"
   "Mindy Preston"
   "Thomas Leonard"
+  "David Scott"
+  "Gabor Pali"
+  "Hannes Mehnert"
+  "Haris Rotsos"
+  "Kia"
+  "Luke Dunstan"
+  "Pablo Polvorin"
+  "Tim Cuthbertson"
+  "lnmx"
+  "pqwy"
 ]
+license: "ISC"
 tags: ["org:mirage"]
 
 build: [


### PR DESCRIPTION
- opam file now declares an ISC license
- opam file has a more complete author list, derived from git metadata

Signed-off-by: David Scott <dave@recoil.org>