### PR TITLE
[Tracking] Remove console

### DIFF
--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -27,7 +27,6 @@ module type TCPV4_DIRECT = V1_LWT.TCPV4
   with type ipinput = direct_ipv4_input
 
 module Make
-    (Console : V1_LWT.CONSOLE)
     (Time    : V1_LWT.TIME)
     (Random  : V1.RANDOM)
     (Netif   : V1_LWT.NETWORK)
@@ -40,11 +39,10 @@ module Make
 struct
 
   type +'a io = 'a Lwt.t
-  type ('a,'b,'c) config = ('a,'b,'c) V1_LWT.stackv4_config
-  type console = Console.t
+  type ('a,'b) config = ('a,'b) V1_LWT.stackv4_config
   type netif = Netif.t
   type mode = V1_LWT.direct_stack_config
-  type id = (console, netif, mode) config
+  type id = (netif, mode) config
   type buffer = Cstruct.t
   type arpv4 = Arpv4.t
   type ipv4addr = Ipaddr.V4.t

--- a/lib/tcpip_stack_direct.mli
+++ b/lib/tcpip_stack_direct.mli
@@ -22,7 +22,6 @@ module type TCPV4_DIRECT = V1_LWT.TCPV4
   with type ipinput = direct_ipv4_input
 
 module Make
-    (Console : V1_LWT.CONSOLE)
     (Time    : V1_LWT.TIME)
     (Random  : V1.RANDOM)
     (Netif   : V1_LWT.NETWORK)
@@ -33,8 +32,7 @@ module Make
     (Udpv4   : UDPV4_DIRECT with type ip = Ipv4.t)
     (Tcpv4   : TCPV4_DIRECT with type ip = Ipv4.t) : sig
   include V1_LWT.STACKV4
-    with type console = Console.t
-     and type netif   = Netif.t
+    with type netif   = Netif.t
      and type mode    = V1_LWT.direct_stack_config
      and type udpv4   = Udpv4.t
      and type tcpv4   = Tcpv4.t
@@ -42,7 +40,7 @@ module Make
      and module IPV4 = Ipv4
      and module TCPV4 = Tcpv4
      and module UDPV4 = Udpv4
-  val connect : (console, netif, mode) V1_LWT.stackv4_config ->
+  val connect : (netif, mode) V1_LWT.stackv4_config ->
     Ethif.t -> Arpv4.t -> Ipv4.t -> Icmpv4.t -> Udpv4.t -> Tcpv4.t ->
     [> `Ok of t | `Error of error ] Lwt.t
 end

--- a/opam
+++ b/opam
@@ -43,7 +43,7 @@ depends: [
   "ocamlfind" {build}
   "result"
   "rresult"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "2.1.0"}
   "ppx_tools"
   "mirage-types" {>= "2.8.0"}
   "mirage-console"

--- a/unix/tcpip_stack_socket.ml
+++ b/unix/tcpip_stack_socket.ml
@@ -32,117 +32,114 @@ module type TCPV4_SOCKET = V1_LWT.TCP
 module Tcpv4 = Tcpv4_socket
 module Udpv4 = Udpv4_socket
 
-module Make(Console:V1_LWT.CONSOLE) = struct
-  type +'a io = 'a Lwt.t
-  type ('a,'b,'c) config = ('a,'b,'c) V1_LWT.stackv4_config
-  type console = Console.t
-  type netif = Ipaddr.V4.t list
-  type mode = unit
-  type id = (console, netif, mode) config
-  type buffer = Cstruct.t
-  type ipv4addr = Ipaddr.V4.t
+type +'a io = 'a Lwt.t
+type ('a,'b) config = ('a,'b) V1_LWT.stackv4_config
+type netif = Ipaddr.V4.t list
+type mode = unit
+type id = (netif, mode) config
+type buffer = Cstruct.t
+type ipv4addr = Ipaddr.V4.t
 
-  module TCPV4 = Tcpv4_socket
-  module UDPV4 = Udpv4_socket
-  module IPV4  = Ipv4_socket
+module TCPV4 = Tcpv4_socket
+module UDPV4 = Udpv4_socket
+module IPV4  = Ipv4_socket
 
-  type udpv4 = Udpv4_socket.t
-  type tcpv4 = Tcpv4_socket.t
-  type ipv4  = Ipaddr.V4.t option
+type udpv4 = Udpv4_socket.t
+type tcpv4 = Tcpv4_socket.t
+type ipv4  = Ipaddr.V4.t option
 
-  type t = {
-    id    : id;
-    udpv4 : Udpv4.t;
-    tcpv4 : Tcpv4.t;
-    udpv4_listeners: (int, Udpv4.callback) Hashtbl.t;
-    tcpv4_listeners: (int, (Tcpv4.flow -> unit Lwt.t)) Hashtbl.t;
-  }
+type t = {
+  id    : id;
+  udpv4 : Udpv4.t;
+  tcpv4 : Tcpv4.t;
+  udpv4_listeners: (int, Udpv4.callback) Hashtbl.t;
+  tcpv4_listeners: (int, (Tcpv4.flow -> unit Lwt.t)) Hashtbl.t;
+}
 
-  type error = [
-      `Unknown of string
-  ]
+type error = [
+    `Unknown of string
+]
 
-  let id { id; _ } = id
-  let udpv4 { udpv4; _ } = udpv4
-  let tcpv4 { tcpv4; _ } = tcpv4
-  let ipv4 _ = None
+let id { id; _ } = id
+let udpv4 { udpv4; _ } = udpv4
+let tcpv4 { tcpv4; _ } = tcpv4
+let ipv4 _ = None
 
-  (* List of IP addresses to bind to *)
-  let configure t addrs =
-    match addrs with
-    | [] -> return_unit
-    | [any] when Ipaddr.V4.(compare any) any = 0 -> return_unit
-    | _ -> Log.warn (fun f -> f "Manager: socket config currently ignored (TODO)"); return_unit
+(* List of IP addresses to bind to *)
+let configure t addrs =
+  match addrs with
+  | [] -> return_unit
+  | [any] when Ipaddr.V4.(compare any) any = 0 -> return_unit
+  | _ -> Log.warn (fun f -> f "Manager: socket config currently ignored (TODO)"); return_unit
 
-  let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p
+let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p
 
-  let listen_udpv4 t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      let fd = Udpv4.get_udpv4_listening_fd t.udpv4 port in
-      let buf = Cstruct.create 4096 in
-      let rec loop () =
-        let continue () =
-          (* TODO cancellation *)
-          if true then loop () else return_unit in
-        Lwt_cstruct.recvfrom fd buf []
-        >>= fun (len, sa) ->
-        let buf = Cstruct.sub buf 0 len in
-        begin match sa with
-              | Lwt_unix.ADDR_INET (addr, src_port) ->
-                 let src = Ipaddr_unix.V4.of_inet_addr_exn addr in
-                 let dst = Ipaddr.V4.any in (* TODO *)
-                 callback ~src ~dst ~src_port buf
-              | _ -> return_unit
-        end >>= fun () ->
-        continue ()
-      in
-      (* FIXME: we should not ignore the result *)
-      ignore_result (loop ())
+let listen_udpv4 t ~port callback =
+  if port < 0 || port > 65535 then
+    raise (Invalid_argument (err_invalid_port port))
+  else
+    let fd = Udpv4.get_udpv4_listening_fd t.udpv4 port in
+    let buf = Cstruct.create 4096 in
+    let rec loop () =
+      let continue () =
+        (* TODO cancellation *)
+        if true then loop () else return_unit in
+      Lwt_cstruct.recvfrom fd buf []
+      >>= fun (len, sa) ->
+      let buf = Cstruct.sub buf 0 len in
+      begin match sa with
+            | Lwt_unix.ADDR_INET (addr, src_port) ->
+               let src = Ipaddr_unix.V4.of_inet_addr_exn addr in
+               let dst = Ipaddr.V4.any in (* TODO *)
+               callback ~src ~dst ~src_port buf
+            | _ -> return_unit
+      end >>= fun () ->
+      continue ()
+    in
+    (* FIXME: we should not ignore the result *)
+    ignore_result (loop ())
 
-  let listen_tcpv4 _t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      let open Lwt_unix in
-      let fd = socket PF_INET SOCK_STREAM 0 in
-      setsockopt fd SO_REUSEADDR true;
-      let interface = Ipaddr_unix.V4.to_inet_addr Ipaddr.V4.any in (* TODO *)
-      bind fd (ADDR_INET (interface, port));
-      listen fd 10;
-      let rec loop () =
-        let continue () =
-          (* TODO cancellation *)
-          if true then loop () else return_unit in
-        Lwt_unix.accept fd
-        >>= fun (afd, _) ->
-        Lwt.async (fun () ->
-                   Lwt.catch
-                     (fun () -> callback afd)
-                     (fun _ -> return_unit)
-                  );
-        return_unit
-        >>= fun () ->
-        continue ();
-      in
-      (* FIXME: we should not ignore the result *)
-      ignore_result (loop ())
+let listen_tcpv4 _t ~port callback =
+  if port < 0 || port > 65535 then
+    raise (Invalid_argument (err_invalid_port port))
+  else
+    let open Lwt_unix in
+    let fd = socket PF_INET SOCK_STREAM 0 in
+    setsockopt fd SO_REUSEADDR true;
+    let interface = Ipaddr_unix.V4.to_inet_addr Ipaddr.V4.any in (* TODO *)
+    bind fd (ADDR_INET (interface, port));
+    listen fd 10;
+    let rec loop () =
+      let continue () =
+        (* TODO cancellation *)
+        if true then loop () else return_unit in
+      Lwt_unix.accept fd
+      >>= fun (afd, _) ->
+      Lwt.async (fun () ->
+                 Lwt.catch
+                   (fun () -> callback afd)
+                   (fun _ -> return_unit)
+                );
+      return_unit
+      >>= fun () ->
+      continue ();
+    in
+    (* FIXME: we should not ignore the result *)
+    ignore_result (loop ())
 
-  let listen _t =
-    let t, _ = Lwt.task () in
-    t (* TODO cancellation *)
+let listen _t =
+  let t, _ = Lwt.task () in
+  t (* TODO cancellation *)
 
-  let connect id udpv4 tcpv4 =
-    let { V1_LWT.interface; _ } = id in
-    Log.info (fun f -> f "Manager: connect");
-    let udpv4_listeners = Hashtbl.create 7 in
-    let tcpv4_listeners = Hashtbl.create 7 in
-    let t = { id; tcpv4; udpv4; udpv4_listeners; tcpv4_listeners } in
-    Log.info (fun f -> f "Manager: configuring");
-    configure t interface
-    >>= fun () ->
-    return (`Ok t)
+let connect id udpv4 tcpv4 =
+  let { V1_LWT.interface; _ } = id in
+  Log.info (fun f -> f "Manager: connect");
+  let udpv4_listeners = Hashtbl.create 7 in
+  let tcpv4_listeners = Hashtbl.create 7 in
+  let t = { id; tcpv4; udpv4; udpv4_listeners; tcpv4_listeners } in
+  Log.info (fun f -> f "Manager: configuring");
+  configure t interface
+  >>= fun () ->
+  return (`Ok t)
 
-  let disconnect _ = return_unit
-end
+let disconnect _ = return_unit

--- a/unix/tcpip_stack_socket.mli
+++ b/unix/tcpip_stack_socket.mli
@@ -14,17 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make(Console:V1_LWT.CONSOLE) : sig
-  include V1_LWT.STACKV4
-    with type console = Console.t
-     and type netif   = Ipaddr.V4.t list
-     and type mode    = unit
-     and type tcpv4   = Tcpv4_socket.t
-     and type udpv4   = Udpv4_socket.t
-     and type ipv4    = Ipaddr.V4.t option
-     and module UDPV4 = Udpv4_socket
-     and module TCPV4 = Tcpv4_socket
-     and module IPV4  = Ipv4_socket
-  val connect : (console, netif, mode) V1_LWT.stackv4_config ->
-    Udpv4_socket.t -> Tcpv4_socket.t -> [> `Ok of t | `Error of error ] Lwt.t
-end
+include V1_LWT.STACKV4
+  with type netif   = Ipaddr.V4.t list
+   and type mode    = unit
+   and type tcpv4   = Tcpv4_socket.t
+   and type udpv4   = Udpv4_socket.t
+   and type ipv4    = Ipaddr.V4.t option
+   and module UDPV4 = Udpv4_socket
+   and module TCPV4 = Tcpv4_socket
+   and module IPV4  = Ipv4_socket
+val connect : (netif, mode) V1_LWT.stackv4_config ->
+  Udpv4_socket.t -> Tcpv4_socket.t -> [> `Ok of t | `Error of error ] Lwt.t


### PR DESCRIPTION
This is to be applied on top of https://github.com/mirage/mirage-tcpip/pull/199

It removes the unused console arguments, but requires changes to mirage and other code using the library.