### PR TITLE
express dependency on `fmt` for test output

### DIFF
--- a/opam
+++ b/opam
@@ -54,6 +54,7 @@ depends: [
   "mirage-vnetif" {test}
   "alcotest" {test}
   "pcap-format" {test}
+  "fmt" {test}
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.6.0"}
 ]


### PR DESCRIPTION
Using the "fmt" logs reporter as we now do in `lib_test/test.ml` necessitates having `fmt` installed.