### PR TITLE
Enable compiler warnings; fix them.

### DIFF
--- a/_tags
+++ b/_tags
@@ -236,4 +236,4 @@ true: annot, bin_annot
 <lib_test/*.ml{,i,y}>: use_udp
 <lib_test/test.{native,byte}>: custom
 # OASIS_STOP
-true: annot, bin_annot, principal, strict_sequence, debug
+true: annot, bin_annot, principal, strict_sequence, debug, warn(A-4-50)

--- a/lib/arpv4/arpv4.ml
+++ b/lib/arpv4/arpv4.ml
@@ -88,8 +88,9 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
       Hashtbl.replace t.cache ip (Confirmed (expire, mac))
 
   let output t arp =
+    let open Arpv4_packet in
     (* Obtain a buffer to write into *)
-    let payload = Arpv4_packet.Marshal.make_cstruct arp in
+    let payload = Marshal.make_cstruct arp in
     let ethif_packet = Ethif_packet.(Marshal.make_cstruct {
         source = arp.sha;
         destination = arp.tha;
@@ -99,11 +100,12 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
 
   (* Input handler for an ARP packet *)
   let input t frame =
+    let open Arpv4_packet in
     MProf.Trace.label "arpv4.input";
-    match Arpv4_packet.Unmarshal.of_cstruct frame with
+    match Unmarshal.of_cstruct frame with
     | Result.Error s ->
       Log.info (fun f -> f "Failed to parse arpv4 header: %a (buffer: %S)"
-                   Arpv4_packet.Unmarshal.pp_error s (Cstruct.to_string frame));
+                   Unmarshal.pp_error s (Cstruct.to_string frame));
       Lwt.return_unit
     | Result.Ok arp ->
       match arp.op with

--- a/lib/arpv4/arpv4.ml
+++ b/lib/arpv4/arpv4.ml
@@ -88,12 +88,11 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
       Hashtbl.replace t.cache ip (Confirmed (expire, mac))
 
   let output t arp =
-    let open Arpv4_packet in
-    (* Obtain a buffer to write into *)
-    let payload = Marshal.make_cstruct arp in
+    let (source, destination) = Arpv4_packet.(arp.sha, arp.tha) in
+    let payload = Arpv4_packet.Marshal.make_cstruct arp in
     let ethif_packet = Ethif_packet.(Marshal.make_cstruct {
-        source = arp.sha;
-        destination = arp.tha;
+	source;
+        destination;
         ethertype = Ethif_wire.ARP;
       }) in
     Ethif.writev t.ethif [ethif_packet ; payload]

--- a/lib/arpv4/arpv4.ml
+++ b/lib/arpv4/arpv4.ml
@@ -16,7 +16,6 @@
  *)
 
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "arpv4" ~doc:"Mirage ARP module"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/lib/ethif/ethif.ml
+++ b/lib/ethif/ethif.ml
@@ -45,11 +45,12 @@ module Make(Netif : V1_LWT.NETWORK) = struct
   let tags = Logs.Tag.def "Ethif MAC" pp_mac (* definition for a mac tag *)
 
   let input ~arpv4 ~ipv4 ~ipv6 t frame =
+    let open Ethif_packet in
     MProf.Trace.label "ethif.input";
     let of_interest dest =
       Macaddr.compare dest (mac t) = 0 || not (Macaddr.is_unicast dest)
     in
-    match Ethif_packet.Unmarshal.of_cstruct frame with
+    match Unmarshal.of_cstruct frame with
     | Ok (header, payload) when of_interest header.destination ->
       begin
         let open Ethif_wire in

--- a/lib/ethif/ethif.ml
+++ b/lib/ethif/ethif.ml
@@ -15,7 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-open Lwt.Infix
 open Result
 
 let src = Logs.Src.create "ethif" ~doc:"Mirage Ethernet"
@@ -38,11 +37,7 @@ module Make(Netif : V1_LWT.NETWORK) = struct
     netif: Netif.t;
   }
 
-  let id t = t.netif
   let mac t = Netif.mac t.netif
-
-  let pp_mac fmt mac = Format.fprintf fmt "%s" (Macaddr.to_string mac)
-  let tags = Logs.Tag.def "Ethif MAC" pp_mac (* definition for a mac tag *)
 
   let input ~arpv4 ~ipv4 ~ipv6 t frame =
     let open Ethif_packet in
@@ -59,7 +54,7 @@ module Make(Netif : V1_LWT.NETWORK) = struct
         | IPv4 -> ipv4 payload
         | IPv6 -> ipv6 payload
       end
-    | Ok header -> Lwt.return_unit
+    | Ok _ -> Lwt.return_unit
     | Error s -> Log.debug (fun f -> f "Dropping Ethernet frame: %s" s);
       Lwt.return_unit
 

--- a/lib/icmp/icmpv4.ml
+++ b/lib/icmp/icmpv4.ml
@@ -1,5 +1,3 @@
-open Result
-
 let src = Logs.Src.create "icmpv4" ~doc:"Mirage ICMPv4"
 module Log = (val Logs.src_log src : Logs.LOG)
 

--- a/lib/ipv4/ipv4.ml
+++ b/lib/ipv4/ipv4.ml
@@ -34,7 +34,6 @@ module Make(Ethif: V1_LWT.ETHIF) (Arpv4 : V1_LWT.ARP) = struct
   type ipaddr = Ipaddr.V4.t
   type prefix = Ipaddr.V4.t
   type callback = src:ipaddr -> dst:ipaddr -> buffer -> unit Lwt.t
-  type macaddr = Ethif.macaddr
 
   type t = {
     ethif : Ethif.t;
@@ -43,11 +42,6 @@ module Make(Ethif: V1_LWT.ETHIF) (Arpv4 : V1_LWT.ARP) = struct
     mutable netmask: Ipaddr.V4.t;
     mutable gateways: Ipaddr.V4.t list;
   }
-
-  let input_arpv4 t buf =
-    Arpv4.input t.arp buf
-
-  let id { ethif; _ } = ethif
 
   module Routing = struct
 
@@ -146,7 +140,8 @@ module Make(Ethif: V1_LWT.ETHIF) (Arpv4 : V1_LWT.ARP) = struct
   let write t frame buf =
     writev t frame [buf]
 
-  let input t ~tcp ~udp ~default buf =
+  (* TODO: ought we to check to make sure the destination is relevant here?  currently we'll process all incoming packets, regardless of destination address *)
+  let input _t ~tcp ~udp ~default buf =
     let open Ipv4_packet in
     match Unmarshal.of_cstruct buf with
     | Error s ->

--- a/lib/ipv4/ipv4.ml
+++ b/lib/ipv4/ipv4.ml
@@ -147,12 +147,13 @@ module Make(Ethif: V1_LWT.ETHIF) (Arpv4 : V1_LWT.ARP) = struct
     writev t frame [buf]
 
   let input t ~tcp ~udp ~default buf =
-    match Ipv4_packet.Unmarshal.of_cstruct buf with
+    let open Ipv4_packet in
+    match Unmarshal.of_cstruct buf with
     | Error s ->
       Log.info (fun f -> f "IP.input: unparseable header (%s): %S" s (Cstruct.to_string buf));
       Lwt.return_unit
     | Ok (packet, payload) ->
-      match Ipv4_packet.Unmarshal.int_to_protocol packet.proto, Cstruct.len payload with
+      match Unmarshal.int_to_protocol packet.proto, Cstruct.len payload with
       | Some _, 0 ->
         (* Don't pass on empty buffers as payloads to known protocols, as they have no relevant headers *)
         Lwt.return_unit

--- a/lib/ipv4/ipv4_packet.ml
+++ b/lib/ipv4/ipv4_packet.ml
@@ -45,7 +45,7 @@ module Unmarshal = struct
         else Result.Ok hlen
       end
     in
-    let check_header_len buf options_end =
+    let check_header_len options_end =
       if options_end < sizeof_ipv4 then Result.Error
           (Printf.sprintf "IPv4 header claimed to have size < 20: %d" options_end)
       else Result.Ok options_end
@@ -63,7 +63,7 @@ module Unmarshal = struct
       let payload = Cstruct.sub buf options_end payload_len in
       Ok ({src; dst; proto; ttl; options;}, payload)
     in
-    get_header_length buf >>= check_header_len buf >>= parse buf
+    get_header_length buf >>= check_header_len >>= parse buf
 end
 module Marshal = struct
   open Ipv4_wire

--- a/lib/ipv6/ipv6.ml
+++ b/lib/ipv6/ipv6.ml
@@ -37,8 +37,6 @@ module Make (E : V1_LWT.ETHIF) (T : V1_LWT.TIME) (C : V1.CLOCK) = struct
     [ `Unimplemented
     | `Unknown of string ]
 
-  let id { ethif } = ethif
-
   let start_ticking t =
     let rec loop () =
       let now = C.time () in
@@ -67,7 +65,7 @@ module Make (E : V1_LWT.ETHIF) (T : V1_LWT.TIME) (C : V1.CLOCK) = struct
 
   let input t ~tcp ~udp ~default buf =
     let now = C.time () in
-    let ctx, bufs, actions = Ndpv6.handle ~now t.ctx buf in
+    let _, bufs, actions = Ndpv6.handle ~now t.ctx buf in
     Lwt_list.iter_s (function
         | `Tcp (src, dst, buf) -> tcp ~src ~dst buf
         | `Udp (src, dst, buf) -> udp ~src ~dst buf

--- a/lib/ipv6/ndpv6.ml
+++ b/lib/ipv6/ndpv6.ml
@@ -707,6 +707,7 @@ module RouterList = struct
 
   let add rl ~now ?(lifetime = max_float) ip =
     (* FIXME *)
+    (* yomimono 2016-06-30: fix what? *)
     (ip, now +. lifetime) :: rl
 
   (* FIXME if we are keeping a destination cache, we must remove the stale routers from there as well. *)
@@ -1174,11 +1175,11 @@ let get_ip ctx =
 
 let allocate_frame ctx dst proto =
   let proto = Ipv6_wire.protocol_to_int proto in
-  let src = AddressList.select_source ctx.address_list dst in
+  let src = AddressList.select_source ctx.address_list ~dst in
   Allocate.frame ~mac:ctx.mac ~src ~hlim:ctx.cur_hop_limit ~dst ~proto
 
 let select_source ctx dst =
-  AddressList.select_source ctx.address_list dst
+  AddressList.select_source ctx.address_list ~dst
 
 let handle_ra ~now ctx ~src ~dst ra =
   Log.debug (fun f -> f "ND: Received RA: src=%a dst=%a" Ipaddr.pp_hum src Ipaddr.pp_hum dst);
@@ -1295,7 +1296,7 @@ let handle ~now ctx buf =
     let dst = src
     and src =
       if Ipaddr.is_multicast dst then
-        AddressList.select_source ctx.address_list dst
+        AddressList.select_source ctx.address_list ~dst
       else
         dst
     in

--- a/lib/ipv6/ndpv6.ml
+++ b/lib/ipv6/ndpv6.ml
@@ -74,13 +74,13 @@ let solicited_node_prefix =
   Ipaddr.(Prefix.make 104 (of_int16 (0xff02, 0, 0, 0, 0, 1, 0xff00, 0)))
 
 module Defaults = struct
-  let max_rtr_solicitation_delay = 1.0
-  let ptr_solicitation_interval  = 4
-  let max_rtr_solicitations      = 3
+  let _max_rtr_solicitation_delay = 1.0
+  let _ptr_solicitation_interval  = 4
+  let _max_rtr_solicitations      = 3
   let max_multicast_solicit      = 3
   let max_unicast_solicit        = 3
-  let max_anycast_delay_time     = 1
-  let max_neighbor_advertisement = 3
+  let _max_anycast_delay_time     = 1
+  let _max_neighbor_advertisement = 3
   let delay_first_probe_time     = 5.0
 
   let link_mtu                   = 1500 (* RFC 2464, 2. *)
@@ -182,7 +182,7 @@ module Allocate = struct
     let header_len = Ethif_wire.sizeof_ethernet + Ipv6_wire.sizeof_ipv6 in
     (ethernet_frame, header_len)
 
-  let error ~mac ~src ~dst ~ty ~code ?(reserved = 0l) buf =
+  let _error ~mac ~src ~dst ~ty ~code ?(reserved = 0l) buf =
     let eth_frame, header_len = frame ~mac ~src ~dst ~hlim:255 ~proto:58 in
     let eth_frame = Cstruct.set_len eth_frame (header_len + Ipv6_wire.sizeof_icmpv6) in
     let maxbuf = Defaults.min_link_mtu - (header_len + Ipv6_wire.sizeof_icmpv6) in
@@ -360,7 +360,7 @@ module AddressList = struct
         ips, acts
       ) al ([], [])
 
-  let expired al ~now =
+  let _expired al ~now =
     List.exists (function
         | _, TENTATIVE (_, _, t)
         | _, PREFERRED (Some (t, _))
@@ -396,7 +396,7 @@ module AddressList = struct
   let configure al ~now ~retrans_timer ~lft mac pfx =
     (* FIXME is this the same as add ? *)
     match find_prefix al pfx with
-    | Some addr ->
+    | Some _addr ->
       (* TODO handle already configured SLAAC address 5.5.3 e). *)
       al, []
     | None ->
@@ -727,12 +727,12 @@ module RouterList = struct
       end
     | false ->
       if lft > 0.0 then begin
-        Log.info (fun f -> f "RA: Adding Router: src=%a" Ipaddr.pp_hum src);
-        (src, now +. lft) :: rl, []
+	Log.info (fun f -> f "RA: Adding Router: src=%a" Ipaddr.pp_hum src);
+        (add rl ~now ~lifetime:lft src), []
       end else
         rl, []
 
-  let add rl ~now ip =
+  let add rl ~now:_ ip =
     match List.mem_assoc ip rl with
     | true -> rl
     | false -> (ip, max_float) :: rl

--- a/lib/ipv6/ndpv6.ml
+++ b/lib/ipv6/ndpv6.ml
@@ -231,8 +231,9 @@ module Allocate = struct
   let rs ~mac select_source =
     let dst = Ipaddr.link_routers in
     let src = select_source ~dst in
+    let cmp = Ipaddr.compare in
     let eth_frame, header_len = frame ~mac ~src ~dst ~hlim:255 ~proto:58 in
-    let include_slla = Ipaddr.(compare src unspecified) != 0 in
+    let include_slla = (cmp src Ipaddr.unspecified) != 0 in
     let slla_len = if include_slla then Ipv6_wire.sizeof_llopt else 0 in
     let eth_frame =
       Cstruct.set_len eth_frame (header_len + Ipv6_wire.sizeof_rs + slla_len)

--- a/lib/tcp/flow.ml
+++ b/lib/tcp/flow.ml
@@ -62,14 +62,13 @@ module Make(IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.CLOCK)(R:V1.RANDOM) = struct
     | `Refused -> "Connection refused"
 
   let err_rewrite = function
-    | Result.Error s -> `Error `Refused
+    | Result.Error _ -> `Error `Refused
     | Result.Ok ()   -> `Ok ()
 
   let err_raise = function
-    | Result.Error s -> Lwt.fail Refused
+    | Result.Error _ -> Lwt.fail Refused
     | Result.Ok ()   -> Lwt.return_unit
 
-  let id = Pcb.ip
   let dst = Pcb.dst
   let close t = Pcb.close t
   let input = Pcb.input

--- a/lib/tcp/options.ml
+++ b/lib/tcp/options.ml
@@ -46,7 +46,7 @@ let unmarshal buf =
          match Cstruct.get_uint8 buf 0 with
          | 0 -> None   (* EOF *)
          | 1 -> Some 1 (* NOP *)
-         | n ->
+         | _option_type ->
            match Cstruct.len buf with
            | 0 | 1 -> None
            | buffer_size ->

--- a/lib/tcp/pcb.ml
+++ b/lib/tcp/pcb.ml
@@ -70,8 +70,6 @@ struct
 
   let ip { ip; _ } = ip
 
-  let verify_checksum _ _ _ = true
-
   let wscale_default = 2
 
   module Tx = struct
@@ -150,7 +148,7 @@ struct
     (* Thread that spools the data into an application receive buffer,
        and notifies the ACK subsystem that new data is here *)
     let thread (pcb:pcb) ~rx_data =
-      let { wnd; ack; urx; } = pcb in
+      let { wnd; ack; urx; _ } = pcb in
       (* Thread to monitor application receive and pass it up *)
       let rec rx_application_t () =
         Lwt_mvar.take rx_data >>= fun (data, winadv) ->
@@ -328,7 +326,7 @@ struct
     STATE.tick pcb.state (State.Send_synack params.tx_isn);
     (* Add the PCB to our listens table *)
     if Hashtbl.mem t.listens id then (
-      Log.debug (fun f -> f "duplicate attempt to make a connection: %a .
+      Log.debug (fun f -> f "duplicate attempt to make a connection: %a .\
       Removing the old state and replacing with new attempt" WIRE.pp_id id);
       Hashtbl.remove t.listens id;
       Stats.decr_listen ();
@@ -355,18 +353,21 @@ struct
     TXS.output pcb.txq (Cstruct.create 0) >>= fun () ->
     Lwt.return (pcb, th)
 
+  let is_correct_ack ~tx_isn ~ack_number =
+   (Sequence.compare (Sequence.incr tx_isn) ack_number) = 0
+
   let process_reset t id ~ack ~ack_number =
     Logs.(log_with_stats Debug "process-reset" t);
     if ack then
         match hashtbl_find t.connects id with
         | Some (wakener, tx_isn) ->
           (* We don't send data in the syn request, so the expected ack is tx_isn + 1 *)
-          if Sequence.(compare (incr tx_isn) ack_number = 0) then (
+          if is_correct_ack ~tx_isn ~ack_number then begin
             Hashtbl.remove t.connects id;
             Stats.decr_connect ();
             Lwt.wakeup wakener `Rst;
             Lwt.return_unit
-          ) else
+          end else
             Lwt.return_unit
         | None ->
           match hashtbl_find t.listens id with
@@ -387,7 +388,7 @@ struct
     Logs.(log_with_stats Debug "process-synack" t);
     match hashtbl_find t.connects id with
     | Some (wakener, tx_isn) ->
-      if Sequence.(compare (incr tx_isn) ack_number = 0) then (
+      if is_correct_ack ~tx_isn ~ack_number then (
         Hashtbl.remove t.connects id;
         Stats.decr_connect ();
         let rx_wnd = 65535 in
@@ -427,16 +428,11 @@ struct
       Tx.send_rst t id ~sequence ~ack_number ~syn ~fin
 
   let process_ack t id ~pkt =
-    let open Tcp_packet in
     let open RXS in
     Logs.(log_with_stats Debug "process-ack" t);
-    let ack_number = pkt.header.ack_number in
-    let sequence = pkt.header.sequence in
-    let syn = pkt.header.syn in
-    let fin = pkt.header.fin in
     match hashtbl_find t.listens id with
     | Some (tx_isn, (pushf, newconn)) ->
-      if Sequence.(compare (incr tx_isn) ack_number = 0) then (
+      if Tcp_packet.(is_correct_ack ~tx_isn ~ack_number:pkt.header.ack_number) then begin
         (* Established connection - promote to active channels *)
         Hashtbl.remove t.listens id;
         Stats.decr_listen ();
@@ -446,7 +442,7 @@ struct
         Rx.input t pkt newconn >>= fun () ->
         (* send new connection up to listener *)
         pushf (fst newconn)
-      ) else
+      end else
         (* No RST because we are trying to connect on this id *)
         Lwt.return_unit
     | None ->
@@ -455,28 +451,24 @@ struct
         (* No RST because we are trying to connect on this id *)
         Lwt.return_unit
       | None ->
+        let { sequence; Tcp_packet.ack_number; syn; fin; _ } = pkt.header in
         (* ACK but no matching pcb and no listen - send RST *)
         Tx.send_rst t id ~sequence ~ack_number ~syn ~fin
 
   let input_no_pcb t listeners (parsed, payload) id =
-    let open Tcp_packet in
-    match parsed.rst with
-    | true -> process_reset t id ~ack:parsed.ack ~ack_number:parsed.ack_number
-    | false ->
-      match parsed.syn, parsed.ack with
-      | true , true  -> process_synack t id ~ack_number:parsed.ack_number
-                          ~sequence:parsed.sequence ~tx_wnd:parsed.window
-                          ~options:parsed.options ~syn:parsed.syn ~fin:parsed.fin
-      | true , false -> process_syn t id ~listeners ~tx_wnd:parsed.window
-                          ~ack_number:parsed.ack_number ~sequence:parsed.sequence
-                          ~options:parsed.options ~syn:parsed.syn ~fin:parsed.fin
-      | false, true  ->
-	let open RXS in
-	process_ack t id ~pkt:{ header = parsed; payload}
-      | false, false ->
-        (* No SYN, ACK, or RST, so just drop it *)
-        Log.debug (fun f -> f "incoming packet matches no connection table entry and has no useful flags set; dropping it");
-        Lwt.return_unit
+    let { sequence; Tcp_packet.ack_number; window; options; syn; fin; rst; ack; _ } = parsed in
+    match rst, syn, ack with
+    | true, _, _ -> process_reset t id ~ack ~ack_number
+    | false, true, true ->
+      process_synack t id ~ack_number ~sequence ~tx_wnd:window ~options ~syn ~fin
+    | false, true , false -> process_syn t id ~listeners ~tx_wnd:window
+			       ~ack_number ~sequence ~options ~syn ~fin
+    | false, false, true  ->
+      let open RXS in
+      process_ack t id ~pkt:{ header = parsed; payload}
+    | false, false, false ->
+      Log.debug (fun f -> f "incoming packet matches no connection table entry and has no useful flags set; dropping it");
+      Lwt.return_unit
 
   (* Main input function for TCP packets *)
   let input t ~listeners ~src ~dst data =
@@ -559,7 +551,7 @@ struct
       (match t.localport with
        | 65535 -> t.localport <- 10000
        | _ -> t.localport <- t.localport + 1);
-      let id = WIRE.wire ~src:(Ip.src t.ip dst)
+      let id = WIRE.wire ~src:(Ip.src t.ip ~dst)
           ~src_port:t.localport ~dst ~dst_port in
       if inuse t id then bumpport t else id
     in

--- a/lib/tcp/pcb.mli
+++ b/lib/tcp/pcb.mli
@@ -26,6 +26,9 @@ module Make(Ip:V1_LWT.IP)(Time:V1_LWT.TIME)(Clock:V1.CLOCK)(Random:V1.RANDOM) : 
   (** Result of attempting to open a connection *)
   type connection_result = [ `Ok of connection | `Rst | `Timeout ]
 
+  val pp_pcb : Format.formatter -> pcb -> unit
+  val pp_stats : Format.formatter -> t -> unit
+
   val ip : t -> Ip.t
 
   val input: t -> listeners:(int -> (pcb -> unit Lwt.t) option)

--- a/lib/tcp/segment.ml
+++ b/lib/tcp/segment.ml
@@ -266,16 +266,6 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
     mutable dup_acks: int;         (* dup ack count for re-xmits *)
   }
 
-  let pp_seg fmt seg =
-    Format.fprintf fmt "[%s%a]"
-      (match seg.flags with
-       | No_flags ->""
-       | Syn ->"SYN "
-       | Fin ->"FIN "
-       | Rst -> "RST "
-       | Psh -> "PSH ")
-      Sequence.pp (len seg)
-
   let ack_segment _ _ = ()
   (* Take any action to the user transmit queue due to this being
      successfully ACKed *)

--- a/lib/tcp/tcp_packet.ml
+++ b/lib/tcp/tcp_packet.ml
@@ -101,7 +101,7 @@ module Marshal = struct
       if (Cstruct.len buf) < ((Cstruct.len payload) + header_length) then
         Error (Printf.sprintf "Not enough space for header and payload: %d < %d"
                  (Cstruct.len buf) (Cstruct.len payload + header_length))
-      else Ok ((Cstruct.len payload) + sizeof_tcp)
+      else Ok ()
     in
     let insert_options options_frame =
       match t.options with
@@ -117,7 +117,7 @@ module Marshal = struct
     let options_frame = Cstruct.shift buf sizeof_tcp in
     check_header_len () >>= fun () ->
     insert_options options_frame >>= fun options_len ->
-    check_overall_len (sizeof_tcp + options_len) >>= fun len ->
+    check_overall_len (sizeof_tcp + options_len) >>= fun () ->
     unsafe_fill ~pseudoheader ~payload t buf options_len;
     Ok (sizeof_tcp + options_len)
 

--- a/lib/tcp/user_buffer.ml
+++ b/lib/tcp/user_buffer.ml
@@ -309,13 +309,13 @@ module Tx(Time:V1_LWT.TIME)(Clock:V1.CLOCK) = struct
     clear_buffer t >>= fun () ->
     inform_app t
 
-  (* FIXME: duplicated code with Segment.reset_seq *)
-  let rec reset_seq segs =
-    match Lwt_sequence.take_opt_l segs with
-    | None   -> ()
-    | Some s -> reset_seq segs
-
-  let reset t  =
+  let reset t =
+    (* FIXME: duplicated code with Segment.reset_seq *)
+    let rec reset_seq segs =
+      match Lwt_sequence.take_opt_l segs with
+      | None   -> ()
+      | Some _ -> reset_seq segs
+    in
     reset_seq t.buffer;
     inform_app t
 

--- a/lib/tcp/window.ml
+++ b/lib/tcp/window.ml
@@ -75,8 +75,8 @@ let pp fmt t =
 (* Initialise the sequence space *)
 let t ~rx_wnd_scale ~tx_wnd_scale ~rx_wnd ~tx_wnd ~rx_isn ~tx_mss ~tx_isn =
   let tx_nxt = tx_isn in
-  let rx_nxt = Sequence.(incr rx_isn) in
-  let rx_nxt_inseq = Sequence.(incr rx_isn) in
+  let rx_nxt = Sequence.incr rx_isn in
+  let rx_nxt_inseq = Sequence.incr rx_isn in
   (* TODO: improve this sanity check of tx_mss *)
   let tx_mss = match tx_mss with |None -> default_mss |Some mss -> min mss max_mss in
   let snd_una = tx_nxt in

--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -46,7 +46,6 @@ struct
   type mode = V1_LWT.direct_stack_config
   type id = (console, netif, mode) config
   type buffer = Cstruct.t
-  type arpv4 = Arpv4.t
   type ipv4addr = Ipaddr.V4.t
   type tcpv4 = Tcpv4.t
   type udpv4 = Udpv4.t
@@ -75,7 +74,6 @@ struct
       `Unknown of string
   ]
 
-  let id { id; _ } = id
   let tcpv4 { tcpv4; _ } = tcpv4
   let udpv4 { udpv4; _ } = udpv4
   let ipv4 { ipv4; _ } = ipv4
@@ -181,7 +179,7 @@ struct
     Log.info (fun f -> f "Manager: configuration done");
     Lwt.return (`Ok t)
 
-  let disconnect t =
+  let disconnect _t =
     (* TODO: kill the listening thread *)
     Log.info (fun f -> f "Manager: disconnect");
     Lwt.return_unit

--- a/lib/udp/udp.ml
+++ b/lib/udp/udp.ml
@@ -40,9 +40,8 @@ module Make(Ip: V1_LWT.IP) = struct
     ip : Ip.t;
   }
 
-  let id {ip} = ip
-
-  let input ~listeners t ~src ~dst buf =
+  (* TODO: ought we to check to make sure the destination is relevant here?  Currently we process all incoming packets without making sure they're either unicast for us or otherwise interesting. *)
+  let input ~listeners _t ~src ~dst buf =
     match Udp_packet.Unmarshal.of_cstruct buf with
     | Error s ->
       Log.debug (fun f -> f "Discarding received UDP message: error parsing: %s" s); Lwt.return_unit

--- a/lib/udp/udp_packet.ml
+++ b/lib/udp/udp_packet.ml
@@ -24,8 +24,8 @@ module Unmarshal = struct
         let payload_len = length_from_header - sizeof_udp in
         if payload_len > length_of_buffer
         then Error (Printf.sprintf
-                      "UDP header claimed a payload longer than the supplied
-                      buffer: %d vs %d." payload_len length_of_buffer)
+	      "UDP header claimed a payload longer than the supplied buffer: %d vs %d."
+              payload_len length_of_buffer)
         else Ok payload_len
       end
     in

--- a/lib_test/common.ml
+++ b/lib_test/common.ml
@@ -4,7 +4,7 @@ let fail fmt = Printf.ksprintf OUnit.assert_failure fmt
 
 let or_error name fn t =
   fn t >>= function
-  | `Error e -> fail "or_error starting %s" name
+  | `Error _ -> fail "or_error starting %s" name
   | `Ok t    -> Lwt.return t
 
 let expect_error error name fn t =

--- a/lib_test/test_arp.ml
+++ b/lib_test/test_arp.ml
@@ -240,7 +240,6 @@ let add_get_remove_ips () =
   in
   check "bound ips is an empty list on startup" [];
   A.set_ips stack.arp [ first_ip; first_ip ] >>= fun () ->
-  let ips = A.get_ips stack.arp in
   check "set ips with duplicate elements result in deduplication" [first_ip];
   A.remove_ip stack.arp first_ip >>= fun () ->
   check "ip list is empty after removing only ip" [];

--- a/lib_test/test_arp.ml
+++ b/lib_test/test_arp.ml
@@ -114,7 +114,8 @@ let garp src_mac src_ip =
   }
 
 let fail_on_receipt netif buf = 
-  fail "received traffic when none was expected"
+  Alcotest.fail (Format.asprintf "received traffic when none was expected on interface %s: %a"
+	  (Macaddr.to_string (V.mac netif)) Cstruct.hexdump_pp buf)
 
 let single_check netif expected =
   V.listen netif (fun buf ->
@@ -175,7 +176,7 @@ let three_arp () =
   get_arp ~backend:first.backend () >>= fun third ->
   Lwt.return (first, second, third)
 
-let query_or_die ~arp ~ip ~expected_mac = 
+let query_or_die arp ip expected_mac = 
   A.query arp ip >>= function
   | `Timeout ->
     let pp_ip = Ipaddr.V4.to_string ip in
@@ -193,7 +194,7 @@ let set_and_check listener claimant ip =
   query_or_die listener ip (V.mac claimant.netif)
 
 let start_arp_listener stack () =
-  let noop = (fun buf -> Lwt.return_unit) in
+  let noop = (fun _ -> Lwt.return_unit) in
   E.input ~arpv4:(A.input stack.arp) ~ipv4:noop ~ipv6:noop stack.ethif
 
 let output_then_disconnect ~speak:speak_netif ~disconnect:listen_netif bufs =
@@ -206,7 +207,7 @@ let not_in_cache ~listen probe arp ip =
     single_check listen probe;
     OS.Time.sleep 0.1 >>= fun () ->
     A.query arp ip >>= function
-    | `Ok mac -> fail "entry in cache when it shouldn't be"
+    | `Ok mac -> fail @@ "entry in cache when it shouldn't be" ^ (Macaddr.to_string mac)
     | `Timeout -> Lwt.return_unit
   ]
 
@@ -235,8 +236,7 @@ let set_ip_sends_garp () =
 let add_get_remove_ips () =
   get_arp () >>= fun stack ->
   let check str expected =
-    Alcotest.(check (list ip)) "set ips with duplicate elements result in deduplication"
-      expected (A.get_ips stack.arp)
+    Alcotest.(check (list ip)) str expected (A.get_ips stack.arp)
   in
   check "bound ips is an empty list on startup" [];
   A.set_ips stack.arp [ first_ip; first_ip ] >>= fun () ->
@@ -314,7 +314,7 @@ let input_resolves_wait () =
 let unreachable_times_out () =
   get_arp () >>= fun speak ->
   A.query speak.arp first_ip >>= function
-  | `Ok mac -> fail "query claimed success when impossible"
+  | `Ok mac -> fail @@ "query claimed success when impossible for " ^ (Macaddr.to_string mac)
   | `Timeout -> Lwt.return_unit
 
 let input_replaces_old () =
@@ -360,7 +360,7 @@ let query_retries () =
                                       op  = Arpv4_wire.Request;})
   in
   let how_many = ref 0 in
-  let rec listener buf =
+  let listener buf =
     check_ethif_response expected_query buf;
     if !how_many = 0 then begin
       how_many := !how_many + 1;
@@ -371,7 +371,7 @@ let query_retries () =
     A.query speak.arp first_ip >>= function
     | `Timeout -> fail "Received `Timeout before >1 query";
       Lwt.return_unit
-    | `Ok mac -> fail "got result from query, erroneously";
+    | `Ok mac -> fail(Printf.sprintf"got result from query for %s, erroneously" (Macaddr.to_string mac));
       Lwt.return_unit
   in
   Lwt.pick [

--- a/lib_test/test_arp.ml
+++ b/lib_test/test_arp.ml
@@ -95,7 +95,8 @@ let check_response expected buf =
     Alcotest.(check packet) "parsed packet comparison" expected actual
 
 let check_ethif_response expected buf =
-  match Ethif_packet.Unmarshal.of_cstruct buf with
+  let open Ethif_packet in
+  match Unmarshal.of_cstruct buf with
   | Result.Error s -> Alcotest.fail s
   | Result.Ok ({ethertype; _}, arp) ->
     match ethertype with
@@ -442,9 +443,13 @@ let nonsense_requests () =
   three_arp () >>= fun (answerer, inquirer, checker) ->
   A.set_ips answerer.arp [ answerer_ip ] >>= fun () ->
   let request number =
-    let buf = Arpv4_packet.Marshal.make_cstruct @@
-    { op = Arpv4_wire.Request; sha = (V.mac inquirer.netif); tha = Macaddr.broadcast;
-      spa = inquirer_ip; tpa = answerer_ip } in
+    let open Arpv4_packet in
+    let buf = Marshal.make_cstruct @@
+      { op = Arpv4_wire.Request;
+	sha = (V.mac inquirer.netif);
+	tha = Macaddr.broadcast;
+	spa = inquirer_ip;
+	tpa = answerer_ip } in
     Arpv4_wire.set_arp_op buf number;
     let eth_header = { Ethif_packet.source = (V.mac inquirer.netif);
                        destination = Macaddr.broadcast; 

--- a/lib_test/test_iperf.ml
+++ b/lib_test/test_iperf.ml
@@ -125,7 +125,7 @@ module Test_iperf (B : Vnetif_backends.Backend) = struct
     st.bin_packets <- 0L;
     Lwt.return_unit
 
-  let iperf c s server_done_u flow =
+  let iperf c _s server_done_u flow =
     (* debug is too much for us here *)
     Logs.set_level ~all:true (Some Logs.Info);
     log_s c "Iperf server: Received connection." >>= fun () ->

--- a/lib_test/test_rfc5961.ml
+++ b/lib_test/test_rfc5961.ml
@@ -133,9 +133,11 @@ let ack_for data =
   match Tcp_unmarshal.of_cstruct data with
   | Error s -> Alcotest.fail ("attempting to ack data: " ^ s)
   | Ok (packet, data) ->
-    let data_len = Sequence.of_int ((Cstruct.len data) +
-                   (if packet.fin then 1 else 0) +
-                   (if packet.syn then 1 else 0)) in
+    let open Tcp.Tcp_packet in
+    let data_len =
+      Sequence.of_int ((Cstruct.len data) +
+		       (if packet.fin then 1 else 0) +
+		       (if packet.syn then 1 else 0)) in
     let sequence = packet.sequence in
     let ack_n = Sequence.(add sequence data_len) in
     ack_n

--- a/lib_test/test_rfc5961.ml
+++ b/lib_test/test_rfc5961.ml
@@ -13,13 +13,13 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
-open Lwt
-open Result
 open Common
 
 (*
- * Connects two stacks to the same backend.  One is a complete v4 stack (the sut).
- * The other gives us low level access to inject crafted TCP packets, and check sut behaviour.
+ * Connects two stacks to the same backend.
+ * One is a complete v4 stack (the system under test, referred to as [sut]).
+ * The other gives us low level access to inject crafted TCP packets,
+ * and sends and receives crafted packets to check the [sut] behavior.
  *)
 module VNETIF_STACK = Vnetif_common.VNETIF_STACK(Vnetif_backends.Basic)
 
@@ -90,12 +90,12 @@ let run backend fsm sut () =
             ~arpv4:(A.input arp)
             ~ipv4:(I.input
                      ~tcp: (fun ~src ~dst data -> pushf (Some(src,dst,data)); Lwt.return_unit)
-                     ~udp:(fun ~src ~dst data -> Lwt.return_unit)
-                     ~default:(fun ~proto ~src ~dst data ->
-                         Console.log_s console "DEFAULT")
+                     ~udp:(fun ~src:_ ~dst:_ _data -> Lwt.return_unit)
+                     ~default:(fun ~proto ~src:_ ~dst:_ _data ->
+                         Console.log_s console (Printf.sprintf "DEFAULT: %d" proto))
                      rawip
                   )
-            ~ipv6:(fun buf -> return (Console.log console "IP6"))
+            ~ipv6:(fun _buf -> Lwt.return (Console.log console "IP6"))
             ethif) ));
 
   (* Either both fsm and the sut terminates, or a timeout occurs, or one of the sut/fsm informs an error *)
@@ -116,8 +116,7 @@ let run backend fsm sut () =
     (Lwt_mvar.take error_mbox >>= fun cause ->
      Lwt.return_some cause);
   ] >>= function
-  | None ->
-    Lwt.return_unit
+  | None -> Lwt.return_unit
   | Some err ->
     Alcotest.fail err;
     Lwt.return_unit
@@ -131,8 +130,8 @@ let reply_id_from ~src ~dst data =
 
 let ack_for data =
   match Tcp_unmarshal.of_cstruct data with
-  | Error s -> Alcotest.fail ("attempting to ack data: " ^ s)
-  | Ok (packet, data) ->
+  | Result.Error s -> Alcotest.fail ("attempting to ack data: " ^ s)
+  | Result.Ok (packet, data) ->
     let open Tcp.Tcp_packet in
     let data_len =
       Sequence.of_int ((Cstruct.len data) +
@@ -153,8 +152,9 @@ let ack_from_past data off =
 
 let fail_result_not_expected fail = function
   | `Ok data ->
-    fail "data not expected"
-  | `Error err ->
+    Alcotest.fail (Format.asprintf "data not expected but received: %a"
+		     Cstruct.hexdump_pp data)
+  | `Error _err ->
     fail "error not expected"
   | `Eof ->
     fail "eof"
@@ -164,18 +164,18 @@ let fail_result_not_expected fail = function
 
 
 (* Common sut: able to connect, connection not reset, no data received *)
-let sut_connects_and_remains_connected console stack fail_callback =
+let sut_connects_and_remains_connected _console stack fail_callback =
   let conn = VNETIF_STACK.Stackv4.TCPV4.create_connection (VNETIF_STACK.Stackv4.tcpv4 stack) in
   or_error "connect" conn (server_ip, 80) >>= fun flow ->
   (* We must remain blocked on read, connection shouldn't be terminated.
-   * If after half second that remains true, assume test succed *)
+   * If after half second that remains true, assume test succeeds *)
   Lwt.pick [
     (VNETIF_STACK.Stackv4.TCPV4.read flow >>= fail_result_not_expected fail_callback);
     OS.Time.sleep 0.5 ]
 
 
 let blind_rst_on_syn_scenario =
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -201,7 +201,7 @@ let blind_rst_on_syn_scenario =
   (`WAIT_FOR_SYN, fsm), sut_connects_and_remains_connected
 
 let connection_refused_scenario =
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -214,7 +214,7 @@ let connection_refused_scenario =
         Lwt.return Fsm_done
       ) else
         Lwt.return (Fsm_error "Expected initial syn request") in
-  let sut console stack fail =
+  let sut _console stack _fail =
     let conn = VNETIF_STACK.Stackv4.TCPV4.create_connection (VNETIF_STACK.Stackv4.tcpv4 stack) in
     (* connection must be rejected *)
     expect_error `Refused "connect" conn (server_ip, 80) in 
@@ -222,7 +222,7 @@ let connection_refused_scenario =
 
 
 let blind_rst_on_established_scenario =
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -252,7 +252,7 @@ let blind_rst_on_established_scenario =
   (`WAIT_FOR_SYN, fsm), sut_connects_and_remains_connected
 
 let rst_on_established_scenario =
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -274,7 +274,7 @@ let rst_on_established_scenario =
       ) else
         Lwt.return (Fsm_error "Expected final ack of three step dance") in
 
-  let sut console stack fail_callback =
+  let sut _console stack fail_callback =
     let conn = VNETIF_STACK.Stackv4.TCPV4.create_connection (VNETIF_STACK.Stackv4.tcpv4 stack) in
     or_error "connect" conn (server_ip, 80) >>= fun flow ->
     VNETIF_STACK.Stackv4.TCPV4.read flow >>= function
@@ -286,7 +286,7 @@ let rst_on_established_scenario =
   (`WAIT_FOR_SYN, fsm), sut
 
 let blind_syn_on_established_scenario =
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -317,7 +317,7 @@ let blind_syn_on_established_scenario =
 let blind_data_injection_scenario =
   let page = Io_page.to_cstruct (Io_page.get 1) in
   let page = Cstruct.set_len page 512 in
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -351,7 +351,7 @@ let data_repeated_ack_scenario =
   (* This is the just data transmission with ack in the past but within the acceptable window *)
   let page = Io_page.to_cstruct (Io_page.get 1) in
   let page = Cstruct.set_len page 512 in
-  let fsm console ip state ~src ~dst data =
+  let fsm _console ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
       let syn = Tcp_wire.get_syn data in
@@ -378,13 +378,12 @@ let data_repeated_ack_scenario =
       else
         Lwt.return (Fsm_error "Ack for data expected") in
 
-  let sut console stack fail_callback =
+  let sut _console stack fail_callback =
     let conn = VNETIF_STACK.Stackv4.TCPV4.create_connection (VNETIF_STACK.Stackv4.tcpv4 stack) in
     or_error "connect" conn (server_ip, 80) >>= fun flow ->
     (* We should receive the data *)
     VNETIF_STACK.Stackv4.TCPV4.read flow >>= function
-    | `Ok data ->
-      Lwt.return_unit
+    | `Ok _ -> Lwt.return_unit
     | other -> fail_result_not_expected fail_callback other in
   (`WAIT_FOR_SYN, fsm), sut
 

--- a/lib_test/test_tcp_options.ml
+++ b/lib_test/test_tcp_options.ml
@@ -6,7 +6,7 @@ let errors ?(check_msg = false) exp = function
   | Ok opt ->
     Alcotest.fail (Format.asprintf "Result.Ok %a when Result.error %s expected"
                      Tcp.Options.pps opt exp)
-  | Error p -> if check_msg then Alcotest.(check string) "Result.Error didn't give the expected error message" exp p else ()
+  | Error p -> if check_msg then Alcotest.check Alcotest.string "Result.Error didn't give the expected error message" exp p else ()
 
 let test_unmarshal_bad_mss () =
   let odd_sized_mss = Cstruct.create 3 in
@@ -116,7 +116,7 @@ let test_unmarshal_random_data () =
       Cstruct.hexdump random;
       (* acceptable outcomes: some list of options or the expected exception *)
       match Tcp.Options.unmarshal random with
-      | Error s -> (* Errors are OK, just finish *) Lwt.return_unit
+      | Error _ -> (* Errors are OK, just finish *) Lwt.return_unit
       | Ok l ->
         Tcp.Options.pps Format.std_formatter l;
         (* a really basic truth: the longest list we can have is 64 noops *)

--- a/lib_test/test_udp.ml
+++ b/lib_test/test_udp.ml
@@ -1,7 +1,7 @@
 let fails msg f args =
   match f args with
-  | Result.Ok p -> Alcotest.fail msg
-  | Result.Error s -> ()
+  | Result.Ok _ -> Alcotest.fail msg
+  | Result.Error _ -> ()
 
 let cstruct =
   let module M = struct
@@ -10,6 +10,8 @@ let cstruct =
     let equal = Cstruct.equal
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)
+
+let packet = (module Udp_packet : Alcotest.TESTABLE with type t = Udp_packet.t)
 
 let marshal_unmarshal () =
   let parse = Udp_packet.Unmarshal.of_cstruct in
@@ -24,7 +26,7 @@ let marshal_unmarshal () =
   let with_data = Cstruct.concat [with_data; payload] in
   match Udp_packet.Unmarshal.of_cstruct with_data with
   | Result.Error s -> Alcotest.fail s
-  | Result.Ok (header, data) ->
+  | Result.Ok (_header, data) ->
     Alcotest.(check cstruct) "unmarshalling gives expected data" payload data;
     Lwt.return_unit
 

--- a/lib_test/vnetif_common.ml
+++ b/lib_test/vnetif_common.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt
 open Common
 
 (* TODO Some of these modules and signatures could eventually be moved to mirage-vnetif *)
@@ -83,11 +82,11 @@ module VNETIF_STACK ( B : Vnetif_backends.Backend) : (VNETIF_STACK with type bac
 
   let create_backend_listener backend listenf =
     match (B.register backend) with
-    | `Error e -> fail "Error occured while registering to backend"
+    | `Error _ -> fail "Error occured while registering to backend"
     | `Ok id -> (B.set_listen_fn backend id listenf); id
 
   let disable_backend_listener backend id =
-    B.set_listen_fn backend id (fun buf -> Lwt.return_unit)
+    B.set_listen_fn backend id (fun _buf -> Lwt.return_unit)
 
   let create_pcap_recorder backend channel =
     let header_buf = Cstruct.create Pcap.sizeof_pcap_header in

--- a/unix/tcpv4_socket.ml
+++ b/unix/tcpv4_socket.ml
@@ -51,11 +51,6 @@ let connect id =
 let disconnect _ =
   return_unit
 
-let id {interface} =
-  match interface with
-  | None -> None
-  | Some i -> Some (Ipaddr_unix.V4.of_inet_addr_exn i)
-
 let dst fd =
   match Lwt_unix.getpeername fd with
   | Unix.ADDR_UNIX _ ->

--- a/unix/tcpv6_socket.ml
+++ b/unix/tcpv6_socket.ml
@@ -41,9 +41,9 @@ let error_message = function
   | `Timeout -> "Timeout while attempting to connect"
   | `Refused -> "Connection refused"
 
-let connect id =
+let connect addr =
   let t =
-    match id with
+    match addr with
     | None -> { interface=None }
     | Some ip -> { interface=Some (Ipaddr_unix.V6.to_inet_addr ip) }
   in
@@ -51,11 +51,6 @@ let connect id =
 
 let disconnect _ =
   return_unit
-
-let id {interface} =
-  match interface with
-  | None -> None
-  | Some i -> Some (Ipaddr_unix.V6.of_inet_addr_exn i)
 
 let dst fd =
   match Lwt_unix.getpeername fd with

--- a/unix/tcpv6_socket.mli
+++ b/unix/tcpv6_socket.mli
@@ -18,4 +18,6 @@
 include V1_LWT.TCP with type ip = Ipaddr.V6.t option
                     and type ipaddr = Ipaddr.V6.t
                     and type ipinput = unit Lwt.t
-                    and type flow = Lwt_unix.file_descr
+		    and type flow = Lwt_unix.file_descr
+
+val connect : ip -> [ `Ok of t ] io

--- a/unix/udpv4_socket.ml
+++ b/unix/udpv4_socket.ml
@@ -33,10 +33,9 @@ let get_udpv4_listening_fd {listen_fds;interface} port =
   try
     Hashtbl.find listen_fds (interface,port)
   with Not_found ->
-    let open Lwt_unix in
-    let fd = socket PF_INET SOCK_DGRAM 0 in
-    bind fd (ADDR_INET (interface,port));
-    Hashtbl.add listen_fds (interface,port) fd;
+    let fd = Lwt_unix.(socket PF_INET SOCK_DGRAM 0) in
+    Lwt_unix.bind fd (Lwt_unix.ADDR_INET (interface, port));
+    Hashtbl.add listen_fds (interface, port) fd;
     fd
 
 (** IO operation errors *)

--- a/unix/udpv6_socket.ml
+++ b/unix/udpv6_socket.ml
@@ -34,9 +34,8 @@ let get_udpv6_listening_fd {listen_fds;interface} port =
   try
     Hashtbl.find listen_fds (interface,port)
   with Not_found ->
-    let open Lwt_unix in
-    let fd = socket PF_INET6 SOCK_DGRAM 0 in
-    bind fd (ADDR_INET (interface,port));
+    let fd = Lwt_unix.(socket PF_INET6 SOCK_DGRAM 0) in
+    Lwt_unix.bind fd (Lwt_unix.ADDR_INET (interface,port));
     Hashtbl.add listen_fds (interface,port) fd;
     fd
 


### PR DESCRIPTION
Broadly, address the following issues:
* a large number of unused functions and variables, notably including `id`
* several overly-broad `open` statements
* some error messages which don't include necessary information

The IPv6 module probably needs more attention.  A few TODOs have been noted, particularly that IP and transport-layer modules tend not to verify that buffers submitted to their `input` functions are relevant to the current configuration of `t` (in other words, they are in promiscuous mode by default).

This addresses issue #206  .