### PR TITLE
process incoming ARPs & construct GARPs per RFC 826.

### DIFF
--- a/lib/arpv4/arpv4.ml
+++ b/lib/arpv4/arpv4.ml
@@ -128,9 +128,9 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) = str
   (* Send a gratuitous ARP for our IP addresses *)
   let output_garp t =
     let sha = Ethif.mac t.ethif in
-    let tha = sha in
-    let tpa = Ipaddr.V4.any in
+    let tha = Macaddr.broadcast in
     Lwt_list.iter_s (fun spa ->
+        let tpa = spa in
         let arp = Arpv4_packet.({ op=Arpv4_wire.Request; tha; sha; tpa; spa }) in
         Log.debug (fun f -> f "ARP: sending gratuitous from %a" Arpv4_packet.pp arp);
         output t ~source:(Ethif.mac t.ethif) ~destination:Macaddr.broadcast arp

--- a/lib_test/test_arp.ml
+++ b/lib_test/test_arp.ml
@@ -112,9 +112,9 @@ let garp src_mac src_ip =
   {
     op = Arpv4_wire.Request;
     sha = src_mac;
-    tha = src_mac;
+    tha = Macaddr.broadcast;
     spa = src_ip;
-    tpa = Ipaddr.V4.any;
+    tpa = src_ip;
   }
 
 let fail_on_receipt netif buf = 

--- a/lib_test/test_arp.ml
+++ b/lib_test/test_arp.ml
@@ -107,9 +107,9 @@ let check_ethif_response expected buf =
 let garp src_mac src_ip =
   let open Arpv4_packet in
   {
-    op = Arpv4_wire.Reply;
+    op = Arpv4_wire.Request;
     sha = src_mac;
-    tha = Macaddr.broadcast;
+    tha = src_mac;
     spa = src_ip;
     tpa = Ipaddr.V4.any;
   }


### PR DESCRIPTION
Per RFC 826, don't look at the `op` field of the packet before deciding
whether to use it to update the cache.  Also, construct gratuitous ARP
packets as Requests, not Replies, and set the destination host address
to the source host address.  This fixes #225.