### PR TITLE
cut off payload in buf before calculating the checksum

### DIFF
--- a/lib/tcp/tcp_packet.ml
+++ b/lib/tcp/tcp_packet.ml
@@ -118,6 +118,7 @@ module Marshal = struct
     check_header_len () >>= fun () ->
     insert_options options_frame >>= fun options_len ->
     check_overall_len (sizeof_tcp + options_len) >>= fun () ->
+    let buf = Cstruct.sub buf 0 (sizeof_tcp + options_len) in
     unsafe_fill ~pseudoheader ~payload t buf options_len;
     Ok (sizeof_tcp + options_len)
 

--- a/lib/udp/udp_packet.ml
+++ b/lib/udp/udp_packet.ml
@@ -65,7 +65,8 @@ module Marshal = struct
       else Ok ((Cstruct.len payload) + sizeof_udp)
     in
     check_header_len () >>= check_overall_len >>= fun len ->
-    unsafe_fill ~pseudoheader ~payload t udp_buf len;
+    let buf = Cstruct.sub udp_buf 0 Udp_wire.sizeof_udp in
+    unsafe_fill ~pseudoheader ~payload t buf len;
     Ok ()
 
   let make_cstruct ~pseudoheader ~payload t =


### PR DESCRIPTION
cut off the contents in payload, as they are already included in `~payload` , otherwise `unsafe_fill` gives an incorrect checksum