### PR TITLE
fix checksum calculation for into_cstruct in tcp and udp

### DIFF
--- a/lib/tcp/tcp_packet.ml
+++ b/lib/tcp/tcp_packet.ml
@@ -118,6 +118,7 @@ module Marshal = struct
     check_header_len () >>= fun () ->
     insert_options options_frame >>= fun options_len ->
     check_overall_len (sizeof_tcp + options_len) >>= fun () ->
+    let buf = Cstruct.sub buf 0 (sizeof_tcp + options_len) in
     unsafe_fill ~pseudoheader ~payload t buf options_len;
     Ok (sizeof_tcp + options_len)
 

--- a/lib/udp/udp_packet.ml
+++ b/lib/udp/udp_packet.ml
@@ -44,10 +44,14 @@ module Marshal = struct
 
   let unsafe_fill ~pseudoheader ~payload {src_port; dst_port} udp_buf len =
     let open Udp_wire in
+    let udp_buf = Cstruct.sub udp_buf 0 sizeof_udp in
     set_udp_source_port udp_buf src_port;
     set_udp_dest_port udp_buf dst_port;
     set_udp_length udp_buf len;
     set_udp_checksum udp_buf 0;
+    (* if we've been passed a buffer larger than sizeof_udp, make sure we
+     * consider only the portion which will actually contain the header
+     * when calculating this bit of the checksum *)
     let csum = Tcpip_checksum.ones_complement_list [ pseudoheader ; udp_buf ; payload ] in
     set_udp_checksum udp_buf csum
 

--- a/lib/udp/udp_packet.ml
+++ b/lib/udp/udp_packet.ml
@@ -65,7 +65,8 @@ module Marshal = struct
       else Ok ((Cstruct.len payload) + sizeof_udp)
     in
     check_header_len () >>= check_overall_len >>= fun len ->
-    unsafe_fill ~pseudoheader ~payload t udp_buf len;
+    let buf = Cstruct.sub udp_buf 0 Udp_wire.sizeof_udp in
+    unsafe_fill ~pseudoheader ~payload t buf len;
     Ok ()
 
   let make_cstruct ~pseudoheader ~payload t =


### PR DESCRIPTION
Per @sevenEng 's commit, we incorrectly include the payload information in the checksum twice if `into_cstruct` is passed a buffer larger than the size of the header it expects to write.  Limit the size of the header buffer passed to `ones_complement_list` to avoid this.