### PR TITLE
New clock api

### DIFF
--- a/lib/arpv4/arpv4.mli
+++ b/lib/arpv4/arpv4.mli
@@ -15,11 +15,11 @@
  *
  *)
 
-module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.CLOCK) (Time : V1_LWT.TIME) : sig
+module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.MCLOCK) (Time : V1_LWT.TIME) : sig
   include V1_LWT.ARP
 
   type ethif = Ethif.t
 
   (** [connect] creates a value of type [t]. *)
-  val connect : ethif -> [> `Ok of t | `Error of error ] Lwt.t
+  val connect : ethif -> Clock.t -> [> `Ok of t | `Error of error ] Lwt.t
 end

--- a/lib/ipv4/ipv4_packet.ml
+++ b/lib/ipv4/ipv4_packet.ml
@@ -102,7 +102,10 @@ module Marshal = struct
     set_ipv4_src buf (Ipaddr.V4.to_int32 t.src);
     set_ipv4_dst buf (Ipaddr.V4.to_int32 t.dst);
     Cstruct.blit t.options 0 buf sizeof_ipv4 (Cstruct.len t.options);
-    set_ipv4_len buf (sizeof_ipv4 + (options_len / 4) + (Cstruct.len payload))
+    set_ipv4_len buf (sizeof_ipv4 + (options_len / 4) + (Cstruct.len payload));
+    let checksum = Tcpip_checksum.ones_complement @@ Cstruct.sub buf 0 (20 + options_len) in
+    set_ipv4_csum buf checksum
+
 
   let into_cstruct ~payload t buf =
     if Cstruct.len buf < (sizeof_ipv4 + Cstruct.len t.options) then

--- a/lib/ipv6/ipv6.mli
+++ b/lib/ipv6/ipv6.mli
@@ -14,11 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (E : V1_LWT.ETHIF) (T : V1_LWT.TIME) (C : V1.CLOCK) : sig
+module Make (E : V1_LWT.ETHIF) (T : V1_LWT.TIME) (Clock : V1.MCLOCK) : sig
   include V1_LWT.IPV6 with type ethif = E.t
   val connect :
     ?ip:Ipaddr.V6.t ->
     ?netmask:Ipaddr.V6.Prefix.t list ->
     ?gateways:Ipaddr.V6.t list ->
-    ethif -> [> `Ok of t | `Error of error ] Lwt.t
+    ethif -> Clock.t -> [> `Ok of t | `Error of error ] Lwt.t
 end

--- a/lib/ipv6/ndpv6.mli
+++ b/lib/ipv6/ndpv6.mli
@@ -17,6 +17,7 @@
 type buffer = Cstruct.t
 type ipaddr = Ipaddr.V6.t
 type prefix = Ipaddr.V6.Prefix.t
+type time   = int64
 
 val ipaddr_of_cstruct : buffer -> ipaddr
 val ipaddr_to_cstruct_raw : ipaddr -> buffer -> int -> unit
@@ -29,12 +30,12 @@ type event =
 
 type context
 
-val local : now:float -> Macaddr.t -> context * buffer list list
+val local : now:time -> Macaddr.t -> context * buffer list list
 (** [local ~now mac] is a pair [ctx, bufs] where [ctx] is a local IPv6 context
     associated to the hardware address [mac].  [bufs] is a list of ethif packets
     to be sent. *)
 
-val add_ip : now:float -> context -> ipaddr -> context * buffer list list
+val add_ip : now:time -> context -> ipaddr -> context * buffer list list
 (** [add_ip ~now ctx ip] is [ctx', bufs] where [ctx'] is [ctx] updated with a
     new local ip and [bufs] is a list of ethif packets to be sent. *)
 
@@ -49,30 +50,30 @@ val select_source : context -> ipaddr -> ipaddr
 (** [select_source ctx ip] returns the ip that should be put in the source field
     of a packet destined to [ip]. *)
 
-val handle : now:float -> context -> buffer -> context * buffer list list * event list
+val handle : now:time -> context -> buffer -> context * buffer list list * event list
 (** [handle ~now ctx buf] handles an incoming ipv6 packet.  It returns [ctx',
     bufs, evs] where [ctx'] is the updated context, [bufs] is a list of packets to
     be sent and [evs] is a list of packets to be passed to the higher layers (udp,
     tcp, etc) for further processing. *)
 
-val send : now:float -> context -> ipaddr -> buffer -> buffer list -> context * buffer list list
+val send : now:time -> context -> ipaddr -> buffer -> buffer list -> context * buffer list list
 (** [send ~now ctx ip frame bufs] starts route resolution and assembles an ipv6
     packet for sending with header [frame] and body [bufs].  It returns a pair
     [ctx', bufs] where [ctx'] is the updated context and [bufs] is a list of
     packets to be sent. *)
 
-val tick : now:float -> context -> context * buffer list list
+val tick : now:time -> context -> context * buffer list list
 (** [tick ~now ctx] should be called periodically (every 1s is good).  It
     returns [ctx', bufs] where [ctx'] is the updated context and [bufs] is a list of
     packets to be sent. *)
 
-val add_prefix : now:float -> context -> prefix -> context
+val add_prefix : now:time -> context -> prefix -> context
 (** [add_prefix ~now ctx pfx] adds a local prefix to [ctx]. *)
 
 val get_prefix : context -> prefix list
 (** [get_prefix ctx] returns the list of local prefixes known to [ctx]. *)
 
-val add_routers : now:float -> context -> ipaddr list -> context
+val add_routers : now:time -> context -> ipaddr list -> context
 (** [add_routers ~now ctx ips] adds a list of gateways to [ctx] to be used for
     routing. *)
 

--- a/lib/tcp/ack.ml
+++ b/lib/tcp/ack.ml
@@ -105,7 +105,7 @@ module Delayed (Time:V1_LWT.TIME) : M = struct
     let delayedack = last in
     let r = {send_ack; delayedack; delayed; pushpending} in
     let expire = ontimer r in
-    let period = 0.1 in
+    let period = (Duration.of_f 0.1) in
     let timer = TT.t ~period ~expire in
     {r; timer}
 

--- a/lib/tcp/ack.ml
+++ b/lib/tcp/ack.ml
@@ -105,8 +105,8 @@ module Delayed (Time:V1_LWT.TIME) : M = struct
     let delayedack = last in
     let r = {send_ack; delayedack; delayed; pushpending} in
     let expire = ontimer r in
-    let period = (Duration.of_f 0.1) in
-    let timer = TT.t ~period ~expire in
+    let period_ns = Duration.of_ms 100 in
+    let timer = TT.t ~period_ns ~expire in
     {r; timer}
 
 

--- a/lib/tcp/flow.ml
+++ b/lib/tcp/flow.ml
@@ -23,7 +23,7 @@ exception Refused
 let src = Logs.Src.create "flow" ~doc:"Mirage TCP Flow module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.CLOCK)(R:V1.RANDOM) = struct
+module Make(IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.MCLOCK)(R:V1.RANDOM) = struct
 
   module Pcb = Pcb.Make(IP)(TM)(C)(R)
 
@@ -83,7 +83,7 @@ module Make(IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.CLOCK)(R:V1.RANDOM) = struct
   let writev t views = Pcb.writev t views >|= err_rewrite
   let write_nodelay t view = Pcb.write_nodelay t view >>= err_raise
   let writev_nodelay t views = Pcb.writev_nodelay t views >>= err_raise
-  let connect ipv4 = ok (Pcb.create ipv4)
+  let connect ipv4 clock = ok (Pcb.create ipv4 clock)
   let disconnect _ = Lwt.return_unit
 
   let create_connection tcp (daddr, dport) =

--- a/lib/tcp/flow.mli
+++ b/lib/tcp/flow.mli
@@ -18,10 +18,10 @@ exception Refused
 (** {b NOTE}: to be removed in favor of a proper result type in
     V1.write_nodelay and V1.writev_nodelay.*)
 
-module Make (IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.CLOCK)(R:V1.RANDOM) : sig
+module Make (IP:V1_LWT.IP)(TM:V1_LWT.TIME)(C:V1.MCLOCK)(R:V1.RANDOM) : sig
   include V1_LWT.TCP
     with type ip = IP.t
      and type ipaddr = IP.ipaddr
      and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
-  val connect : ip -> [> `Ok of t | `Error of error ] Lwt.t
+  val connect : ip -> C.t -> [> `Ok of t | `Error of error ] Lwt.t
 end

--- a/lib/tcp/pcb.mli
+++ b/lib/tcp/pcb.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make(Ip:V1_LWT.IP)(Time:V1_LWT.TIME)(Clock:V1.CLOCK)(Random:V1.RANDOM) : sig
+module Make(Ip:V1_LWT.IP)(Time:V1_LWT.TIME)(Clock:V1.MCLOCK)(Random:V1.RANDOM) : sig
 
   (** Overall state of the TCP stack *)
   type t
@@ -57,5 +57,5 @@ module Make(Ip:V1_LWT.IP)(Time:V1_LWT.TIME)(Clock:V1.CLOCK)(Random:V1.RANDOM) : 
   val write_nodelay: pcb -> Cstruct.t -> (unit, string) Result.result Lwt.t
   val writev_nodelay: pcb -> Cstruct.t list -> (unit, string) Result.result Lwt.t
 
-  val create: Ip.t -> t
+  val create: Ip.t -> Clock.t -> t
 end

--- a/lib/tcp/segment.ml
+++ b/lib/tcp/segment.ml
@@ -292,6 +292,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.MCLOCK) = struct
           | true ->
             if (Window.max_rexmits_done wnd) then (
               (* TODO - include more in log msg like ipaddrs *)
+              Log.debug (fun f -> f "Max retransmits reached: %a" Window.pp wnd);
               Log.info (fun fmt -> fmt "Max retransmits reached for connection - terminating");
               StateTick.tick st State.Timeout;
               Lwt.return Tcptimer.Stoptimer
@@ -304,6 +305,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.MCLOCK) = struct
               Lwt.async
                 (fun () -> xmit ~flags ~wnd ~options ~seq rexmit_seg.data);
               Window.backoff_rto wnd;
+              Log.debug (fun fmt -> fmt "Backed off! %a" Window.pp wnd);
               Log.debug (fun fmt ->
                   fmt "PUSHING TIMER - new time = %Lu, new seq = %a"
                     (Window.rto wnd) Sequence.pp rexmit_seg.seq);

--- a/lib/tcp/segment.ml
+++ b/lib/tcp/segment.ml
@@ -399,8 +399,8 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.MCLOCK) = struct
     let segs = Lwt_sequence.create () in
     let dup_acks = 0 in
     let expire = ontimer xmit state segs wnd in
-    let period = Window.rto wnd in
-    let rexmit_timer = TT.t ~period ~expire in
+    let period_ns = Window.rto wnd in
+    let rexmit_timer = TT.t ~period_ns ~expire in
     let q =
       { clock; xmit; wnd; state; rx_ack; segs; tx_wnd_update; rexmit_timer; dup_acks }
     in

--- a/lib/tcp/segment.ml
+++ b/lib/tcp/segment.ml
@@ -230,7 +230,7 @@ type tx_flags = (* At most one of Syn/Fin/Rst/Psh allowed *)
   | Rst
   | Psh
 
-module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
+module Tx (Time:V1_LWT.TIME) (Clock:V1.MCLOCK) = struct
 
   module StateTick = State.Make(Time)
   module TT = Tcptimer.Make(Time)
@@ -263,6 +263,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
                                       with this queue *)
     tx_wnd_update: int Lwt_mvar.t; (* Received updates to the transmit window *)
     rexmit_timer: Tcptimer.t;      (* Retransmission timer for this connection *)
+    clock: Clock.t;                (* whom to ask for the time *)
     mutable dup_acks: int;         (* dup ack count for re-xmits *)
   }
 
@@ -282,7 +283,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
           match rexmit_seg.seq = seq with
           | false ->
             Log.debug (fun fmt ->
-                fmt "PUSHING TIMER - new time=%f, new seq=%a"
+                fmt "PUSHING TIMER - new time=%Lu, new seq=%a"
                   (Window.rto wnd) Sequence.pp rexmit_seg.seq);
             let ret =
               Tcptimer.ContinueSetPeriod (Window.rto wnd, rexmit_seg.seq)
@@ -304,7 +305,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
                 (fun () -> xmit ~flags ~wnd ~options ~seq rexmit_seg.data);
               Window.backoff_rto wnd;
               Log.debug (fun fmt ->
-                  fmt "PUSHING TIMER - new time = %f, new seq = %a"
+                  fmt "PUSHING TIMER - new time = %Lu, new seq = %a"
                     (Window.rto wnd) Sequence.pp rexmit_seg.seq);
               let ret =
                 Tcptimer.ContinueSetPeriod (Window.rto wnd, rexmit_seg.seq)
@@ -341,7 +342,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
     let rec tx_ack_t () =
       let serviceack dupack ack_len seq win =
         let partleft = clearsegs q ack_len q.segs in
-        TX.tx_ack q.wnd (Sequence.sub seq partleft) win;
+        TX.tx_ack q.clock q.wnd (Sequence.sub seq partleft) win;
         match dupack || Window.fast_rec q.wnd with
         | true ->
           q.dup_acks <- q.dup_acks + 1;
@@ -392,14 +393,14 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
     in
     tx_ack_t ()
 
-  let create ~xmit ~wnd ~state ~rx_ack ~tx_ack ~tx_wnd_update =
+  let create ~clock ~xmit ~wnd ~state ~rx_ack ~tx_ack ~tx_wnd_update =
     let segs = Lwt_sequence.create () in
     let dup_acks = 0 in
     let expire = ontimer xmit state segs wnd in
     let period = Window.rto wnd in
     let rexmit_timer = TT.t ~period ~expire in
     let q =
-      { xmit; wnd; state; rx_ack; segs; tx_wnd_update; rexmit_timer; dup_acks }
+      { clock; xmit; wnd; state; rx_ack; segs; tx_wnd_update; rexmit_timer; dup_acks }
     in
     let t = rto_t q tx_ack in
     q, t
@@ -418,7 +419,7 @@ module Tx (Time:V1_LWT.TIME) (Clock:V1.CLOCK) = struct
     let seq = Window.tx_nxt wnd in
     let seg = { data; flags; seq } in
     let seq_len = len seg in
-    TX.tx_advance q.wnd seq_len;
+    TX.tx_advance q.clock q.wnd seq_len;
     (* Queue up segment just sent for retransmission if needed *)
     let q_rexmit () =
       match Sequence.(gt seq_len zero) with

--- a/lib/tcp/segment.mli
+++ b/lib/tcp/segment.mli
@@ -55,7 +55,7 @@ type tx_flags = No_flags | Syn | Fin | Rst | Psh
 (** Either Syn/Fin/Rst allowed, but not combinations *)
 
 (** Pre-transmission queue *)
-module Tx (Time:V1_LWT.TIME)(Clock:V1.CLOCK) : sig
+module Tx (Time:V1_LWT.TIME)(Clock:V1.MCLOCK) : sig
 
   type xmit = flags:tx_flags -> wnd:Window.t -> options:Options.t list ->
     seq:Sequence.t -> Cstruct.t -> unit Lwt.t
@@ -64,7 +64,7 @@ module Tx (Time:V1_LWT.TIME)(Clock:V1.CLOCK) : sig
   (** Queue of pre-transmission segments *)
 
   val create:
-    xmit:xmit -> wnd:Window.t -> state:State.t ->
+    clock:Clock.t -> xmit:xmit -> wnd:Window.t -> state:State.t ->
     rx_ack:Sequence.t Lwt_mvar.t ->
     tx_ack:(Sequence.t * int) Lwt_mvar.t ->
     tx_wnd_update:int Lwt_mvar.t -> t * unit Lwt.t

--- a/lib/tcp/tcptimer.ml
+++ b/lib/tcp/tcptimer.ml
@@ -41,6 +41,7 @@ module Make(Time:V1_LWT.TIME) = struct
     Log.debug (fun f -> f "timerloop");
     Stats.incr_timer ();
     let rec aux t s =
+      Log.debug (fun f -> f "timerloop: sleeping for %Lu ns" t.period);
       Time.sleep_ns t.period >>= fun () ->
       t.expire s >>= function
       | Stoptimer ->
@@ -52,7 +53,7 @@ module Make(Time:V1_LWT.TIME) = struct
         Log.debug (fun f -> f "timerloop: continuer");
         aux t d
       | ContinueSetPeriod (p, d) ->
-        Log.debug (fun f -> f "timerloop: coontinuesetperiod");
+        Log.debug (fun f -> f "timerloop: continuesetperiod (new period: %Lu)" p);
         t.period <- p;
         aux t d
     in

--- a/lib/tcp/tcptimer.ml
+++ b/lib/tcp/tcptimer.ml
@@ -28,21 +28,21 @@ type tr =
 
 type t = {
   expire: (Sequence.t -> tr Lwt.t);
-  mutable period: time;
+  mutable period_ns: time;
   mutable running: bool;
 }
 
 module Make(Time:V1_LWT.TIME) = struct
-  let t ~period ~expire =
+  let t ~period_ns ~expire =
     let running = false in
-    {period; expire; running}
+    {period_ns; expire; running}
 
   let timerloop t s =
     Log.debug (fun f -> f "timerloop");
     Stats.incr_timer ();
     let rec aux t s =
-      Log.debug (fun f -> f "timerloop: sleeping for %Lu ns" t.period);
-      Time.sleep_ns t.period >>= fun () ->
+      Log.debug (fun f -> f "timerloop: sleeping for %Lu ns" t.period_ns);
+      Time.sleep_ns t.period_ns >>= fun () ->
       t.expire s >>= function
       | Stoptimer ->
         Stats.decr_timer ();
@@ -53,17 +53,17 @@ module Make(Time:V1_LWT.TIME) = struct
         Log.debug (fun f -> f "timerloop: continuer");
         aux t d
       | ContinueSetPeriod (p, d) ->
-        Log.debug (fun f -> f "timerloop: continuesetperiod (new period: %Lu)" p);
-        t.period <- p;
+        Log.debug (fun f -> f "timerloop: continuesetperiod (new period: %Lu ns)" p);
+        t.period_ns <- p;
         aux t d
     in
     aux t s
 
-  let period t = t.period
+  let period_ns t = t.period_ns
 
-  let start t ?(p=(period t)) s =
+  let start t ?(p=(period_ns t)) s =
     if not t.running then begin
-      t.period <- p;
+      t.period_ns <- p;
       t.running <- true;
       Lwt.async (fun () -> timerloop t s);
       Lwt.return_unit

--- a/lib/tcp/tcptimer.mli
+++ b/lib/tcp/tcptimer.mli
@@ -16,13 +16,15 @@
 
 type t
 
+type time = int64
+
 type tr =
   | Stoptimer
   | Continue of Sequence.t
-  | ContinueSetPeriod of (float * Sequence.t)
+  | ContinueSetPeriod of (time * Sequence.t)
 
 module Make(T:V1_LWT.TIME) : sig
-  val t : period: float -> expire: (Sequence.t -> tr Lwt.t) -> t
+  val t : period: time -> expire: (Sequence.t -> tr Lwt.t) -> t
 
-  val start : t -> ?p:float -> Sequence.t -> unit Lwt.t
+  val start : t -> ?p:time -> Sequence.t -> unit Lwt.t
 end

--- a/lib/tcp/tcptimer.mli
+++ b/lib/tcp/tcptimer.mli
@@ -24,7 +24,7 @@ type tr =
   | ContinueSetPeriod of (time * Sequence.t)
 
 module Make(T:V1_LWT.TIME) : sig
-  val t : period: time -> expire: (Sequence.t -> tr Lwt.t) -> t
+  val t : period_ns: time -> expire: (Sequence.t -> tr Lwt.t) -> t
 
   val start : t -> ?p:time -> Sequence.t -> unit Lwt.t
 end

--- a/lib/tcp/user_buffer.ml
+++ b/lib/tcp/user_buffer.ml
@@ -109,7 +109,7 @@ end
    to decide how to throttle or breakup its data production with this
    information.
 *)
-module Tx(Time:V1_LWT.TIME)(Clock:V1.CLOCK) = struct
+module Tx(Time:V1_LWT.TIME)(Clock:V1.MCLOCK) = struct
 
   module TXS = Segment.Tx(Time)(Clock)
 

--- a/lib/tcp/user_buffer.mli
+++ b/lib/tcp/user_buffer.mli
@@ -26,7 +26,7 @@ module Rx : sig
   val monitor: t -> int32 Lwt_mvar.t -> unit
 end
 
-module Tx(Time:V1_LWT.TIME)(Clock:V1.CLOCK) : sig
+module Tx(Time:V1_LWT.TIME)(Clock:V1.MCLOCK) : sig
 
   type t
 

--- a/lib/tcp/window.ml
+++ b/lib/tcp/window.ml
@@ -17,6 +17,8 @@
 let src = Logs.Src.create "window" ~doc:"Mirage TCP Window module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
+type time = int64
+
 type t = {
   tx_mss: int;
   tx_isn: Sequence.t;
@@ -47,10 +49,10 @@ type t = {
   mutable rtt_timer_on: bool;
   mutable rtt_timer_reset: bool;
   mutable rtt_timer_seq: Sequence.t;
-  mutable rtt_timer_starttime: float;
-  mutable srtt: float;
-  mutable rttvar: float;
-  mutable rto: float;
+  mutable rtt_timer_starttime: time;
+  mutable srtt: time;
+  mutable rttvar: time;
+  mutable rto: int64;
   mutable backoff_count: int;
 }
 
@@ -96,10 +98,10 @@ let t ~rx_wnd_scale ~tx_wnd_scale ~rx_wnd ~tx_wnd ~rx_isn ~tx_mss ~tx_isn =
   let rtt_timer_on = false in
   let rtt_timer_reset = true in
   let rtt_timer_seq = tx_nxt in
-  let rtt_timer_starttime = 0.0 in
-  let srtt = 1.0 in
-  let rttvar = 0.0 in
-  let rto = 3.0 in
+  let rtt_timer_starttime = 0L in
+  let srtt = 1L in
+  let rttvar = 0L in
+  let rto = 3L in
   let backoff_count = 0 in
   { tx_isn; rx_isn; max_rx_wnd; max_tx_wnd;
     ack_serviced; ack_seq; ack_win;
@@ -158,18 +160,18 @@ let set_tx_wnd t sz =
 let tx_mss t =
   t.tx_mss
 
-module Make(Clock:V1.CLOCK) = struct
+module Make(Clock:V1.MCLOCK) = struct
   (* Advance transmitted packet sequence number *)
-  let tx_advance t b =
+  let tx_advance clock t b =
     if not t.rtt_timer_on && not t.fast_recovery then begin
       t.rtt_timer_on <- true;
       t.rtt_timer_seq <- t.tx_nxt;
-      t.rtt_timer_starttime <- Clock.time ();
+      t.rtt_timer_starttime <- Clock.elapsed_ns clock;
     end;
     t.tx_nxt <- Sequence.add t.tx_nxt b
 
   (* An ACK was received - use it to adjust cwnd *)
-  let tx_ack t r win =
+  let tx_ack clock t r win =
     set_tx_wnd t win;
     if t.fast_recovery then begin
       if Sequence.gt r t.snd_una then
@@ -187,16 +189,20 @@ module Make(Clock:V1.CLOCK) = struct
         t.snd_una <- r;
         if t.rtt_timer_on && Sequence.gt r t.rtt_timer_seq then begin
           t.rtt_timer_on <- false;
-          let rtt_m = Clock.time () -. t.rtt_timer_starttime in
+          let rtt_m = Int64.sub (Clock.elapsed_ns clock) t.rtt_timer_starttime in
           if t.rtt_timer_reset then begin
             t.rtt_timer_reset <- false;
-            t.rttvar <- (0.5 *. rtt_m);
+            t.rttvar <- Int64.div rtt_m 2L;
             t.srtt <- rtt_m;
           end else begin
-            t.rttvar <- (((1.0 -. beta) *. t.rttvar) +. (beta *. (abs_float (t.srtt -. rtt_m))));
-            t.srtt <- (((1.0 -. alpha) *. t.srtt) +. (alpha *. rtt_m));
+            let adjusted_rttvar = (1.0 -. beta) *. (Int64.to_float t.rttvar) in
+            let rttvar_addition = beta *. Int64.(sub t.srtt rtt_m |> abs |> to_float) in
+            let adjusted_srtt = (1.0 -. alpha) *. (Int64.to_float t.srtt) in
+            let srtt_addition = alpha *. (Int64.to_float rtt_m) in
+            t.rttvar <- Int64.of_float (adjusted_rttvar +. rttvar_addition);
+            t.srtt <- Int64.of_float (adjusted_srtt +. srtt_addition);
           end;
-          t.rto <- (max 1.0 (t.srtt +. (4.0 *. t.rttvar)));
+          t.rto <- (max 1L (Int64.add t.srtt (Int64.mul 4L t.rttvar)));
         end;
       end;
       let cwnd_incr = match t.cwnd < t.ssthresh with
@@ -244,7 +250,7 @@ let alert_fast_rexmit t _ =
 let rto t =
   match t.backoff_count with
   | 0 -> t.rto
-  | _ -> t.rto *. (2. ** (float_of_int t.backoff_count))
+  | _ -> Int64.(mul t.rto (shift_left 2L t.backoff_count))
 
 let backoff_rto t =
   t.backoff_count <- t.backoff_count + 1;

--- a/lib/tcp/window.ml
+++ b/lib/tcp/window.ml
@@ -67,12 +67,13 @@ let beta = 0.25    (* see RFC 2988 *)
 (* To string for debugging *)
 let pp fmt t =
   Format.fprintf fmt
-    "rx_nxt=%a rx_nxt_inseq=%a tx_nxt=%a rx_wnd=%lu tx_wnd=%lu snd_una=%a"
+    "Window: rx_nxt=%a rx_nxt_inseq=%a tx_nxt=%a rx_wnd=%lu tx_wnd=%lu snd_una=%a backoffs=%d rto=%Lu"
     Sequence.pp t.rx_nxt
     Sequence.pp t.rx_nxt_inseq
     Sequence.pp t.tx_nxt
     t.rx_wnd t.tx_wnd
     Sequence.pp t.snd_una
+    t.backoff_count t.rto
 
 (* Initialise the sequence space *)
 let t ~rx_wnd_scale ~tx_wnd_scale ~rx_wnd ~tx_wnd ~rx_isn ~tx_mss ~tx_isn =

--- a/lib/tcp/window.ml
+++ b/lib/tcp/window.ml
@@ -102,7 +102,7 @@ let t ~rx_wnd_scale ~tx_wnd_scale ~rx_wnd ~tx_wnd ~rx_isn ~tx_mss ~tx_isn =
   let rtt_timer_starttime = 0L in
   let srtt = 1L in
   let rttvar = 0L in
-  let rto = 3L in
+  let rto = (Duration.of_sec 3) in
   let backoff_count = 0 in
   { tx_isn; rx_isn; max_rx_wnd; max_tx_wnd;
     ack_serviced; ack_seq; ack_win;

--- a/lib/tcp/window.mli
+++ b/lib/tcp/window.mli
@@ -28,9 +28,9 @@ val rx_advance_inseq : t -> Sequence.t -> unit
 val rx_nxt : t -> Sequence.t
 val rx_nxt_inseq : t -> Sequence.t
 
-module Make(C:V1.CLOCK) : sig
-  val tx_advance : t -> Sequence.t -> unit
-  val tx_ack: t -> Sequence.t -> int -> unit
+module Make(C:V1.MCLOCK) : sig
+  val tx_advance : C.t -> t -> Sequence.t -> unit
+  val tx_ack: C.t -> t -> Sequence.t -> int -> unit
 end
 
 val tx_nxt : t -> Sequence.t
@@ -63,7 +63,7 @@ val max_tx_wnd : t -> int32
 
 val alert_fast_rexmit : t -> Sequence.t -> unit
 
-val rto : t -> float
+val rto : t -> int64
 val backoff_rto : t -> unit
 val max_rexmits_done : t -> bool
 

--- a/lib_test/static_arp.ml
+++ b/lib_test/static_arp.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-module Make(E : V1_LWT.ETHIF)(Clock : V1.CLOCK) (Time : V1_LWT.TIME) = struct
+module Make(E : V1_LWT.ETHIF)(Clock : V1.MCLOCK) (Time : V1_LWT.TIME) = struct
   module A = Arpv4.Make(E)(Clock)(Time)
   (* generally repurpose A, but substitute input and query, and add functions
      for adding/deleting entries *)
@@ -34,7 +34,7 @@ module Make(E : V1_LWT.ETHIF)(Clock : V1.CLOCK) (Time : V1_LWT.TIME) = struct
   let pp fmt repr =
     Format.fprintf fmt "%s" repr
   
-  let connect e = A.connect e >>= function
+  let connect e clock = A.connect e clock >>= function
     | `Ok base -> Lwt.return (`Ok { base; table = (Hashtbl.create 7) })
     | `Error e -> Lwt.return (`Error e)
   

--- a/lib_test/test_rfc5961.ml
+++ b/lib_test/test_rfc5961.ml
@@ -47,9 +47,10 @@ let create_sut_stack backend =
   VNETIF_STACK.create_stack backend sut_ip netmask [gw]
 
 let create_raw_stack backend =
+  or_error "clock" Mclock.connect () >>= fun clock ->
   or_error "backend" V.connect backend >>= fun netif ->
   or_error "ethif" E.connect netif >>= fun ethif ->
-  or_error "arpv4" A.connect ethif >>= fun arpv4 ->
+  or_error "arpv4" (A.connect ethif) clock >>= fun arpv4 ->
   or_error "ipv4" (I.connect ethif) arpv4 >>= fun ip ->
   Lwt.return (netif, ethif, arpv4, ip)
 


### PR DESCRIPTION
Needed to use tcpip once https://github.com/mirage/mirage/pull/548 is merged.  Testing these changes requires https://github.com/mirage/mirage/pull/548 , https://github.com/mirage/mirage-flow/pull/19 , and https://github.com/mirage/mirage-clock/pull/7 .  Building unikernels with them also requires https://github.com/mirage/mirage-logs/pull/4 .