### PR TITLE
Don't rely on Hashtbl.filter_map_inplace, breaks 4.02.3.

### DIFF
--- a/lib/arpv4/arpv4.ml
+++ b/lib/arpv4/arpv4.ml
@@ -50,18 +50,22 @@ module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.MCLOCK) (Time : V1_LWT.TIME) = st
 
   let rec tick t () =
     let now = Clock.elapsed_ns t.clock in
-    let remove_expired ip entry =
+    let expired = Hashtbl.fold (fun ip entry expired ->
         match entry with
-        | Pending _ -> Some entry
-        | Confirmed (expiry, _) ->
-          if Int64.compare expiry now > -1
-          then Some entry
+        | Pending _ -> entry
+        | Confirmed (t, _) ->
+          if Int64.compare t now > -1 then
+            ip :: expired
           else begin
             Log.info (fun f -> f "ARP: timeout %a" Ipaddr.V4.pp_hum ip);
-            None
-          end
+            expired
+          end)
+        t.cache []
     in
-    Hashtbl.filter_map_inplace remove_expired t.cache;
+    List.iter (fun ip ->
+        Log.info (fun f -> f "ARP: timeout %a" Ipaddr.V4.pp_hum ip);
+        Hashtbl.remove t.cache ip)
+      expired;
     Time.sleep_ns arp_timeout >>= tick t
 
   let to_repr t =


### PR DESCRIPTION
This was only introduced in 4.03.0.

I couldn't really test it.