### PR TITLE
Fix ip parsing when there are options on the datagram

### DIFF
--- a/lib/ipv4/ipv4_packet.ml
+++ b/lib/ipv4/ipv4_packet.ml
@@ -61,7 +61,7 @@ module Unmarshal = struct
       let proto = get_ipv4_proto buf in
       let ttl = get_ipv4_ttl buf in
       let options =
-        if options_end > sizeof_ipv4 then (Cstruct.sub buf sizeof_ipv4 options_end)
+        if options_end > sizeof_ipv4 then (Cstruct.sub buf sizeof_ipv4 (options_end - sizeof_ipv4))
         else (Cstruct.create 0)
       in
       let payload = Cstruct.sub buf options_end payload_len in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -19,6 +19,7 @@ let suite = [
   "socket"         , Test_socket.suite      ;
   "icmpv4"         , Test_icmpv4.suite      ;
   "tcp_options"    , Test_tcp_options.suite ;
+  "ip_options"     , Test_ip_options.suite ;
   "rfc5961"        , Test_rfc5961.suite     ;
   "arp"            , Test_arp.suite         ;
   "connect"        , Test_connect.suite     ;

--- a/lib_test/test_ip_options.ml
+++ b/lib_test/test_ip_options.ml
@@ -1,0 +1,33 @@
+open OUnit
+
+let test_unmarshal_with_options () =
+  let datagram = Cstruct.create 40 in
+  Cstruct.blit_from_string ("\x46\xc0\x00\x28\x00\x00\x40\x00\x01\x02" ^
+                            "\x42\x49\xc0\xa8\x01\x08\xe0\x00\x00\x16\x94\x04\x00\x00\x22" ^
+                            "\x00\xfa\x02\x00\x00\x00\x01\x03\x00\x00\x00\xe0\x00\x00\xfb") 0 datagram 0 40;
+  match Ipv4_packet.Unmarshal.of_cstruct datagram with
+  | Result.Ok ({Ipv4_packet.options ; _}, payload) ->
+      assert_equal (Cstruct.len options) 4;
+      assert_equal (Cstruct.len payload) 16;
+      Lwt.return_unit
+  | _ ->
+      Alcotest.fail "Fail to parse ip packet with options"
+
+
+let test_unmarshal_without_options () =
+  let datagram = Cstruct.create 40 in
+  Cstruct.blit_from_string ("\x45\x00\x00\x28\x19\x29\x40\x00\x34\x06\x98\x75\x36\xb7" ^
+                            "\x9c\xca\xc0\xa8\x01\x08\x00\x50\xca\xa6\x6f\x19\xf4\x76" ^
+                            "\x00\x00\x00\x00\x50\x04\x00\x00\xec\x27\x00\x00") 0 datagram 0 40;
+  match Ipv4_packet.Unmarshal.of_cstruct datagram with
+  | Result.Ok ({Ipv4_packet.options ; _}, payload) ->
+      assert_equal (Cstruct.len options) 0;
+      assert_equal (Cstruct.len payload) 20;
+      Lwt.return_unit
+  | _ ->
+      Alcotest.fail "Fail to parse ip packet with options"
+
+let suite = [
+  "unmarshal ip datagram with options", `Quick, test_unmarshal_with_options;
+  "unmarshal ip datagram without options", `Quick, test_unmarshal_without_options
+  ]


### PR DESCRIPTION
Must calculate the options' length.

The IP parsing code was crashing trying to parse some packets that contained IP options, because the option length was incorrect.
