### PR TITLE
fix dependencies: ppx_tools is only needed during build (for cstruct.…

### DIFF
--- a/opam
+++ b/opam
@@ -44,9 +44,9 @@ depends: [
   "result"
   "rresult"
   "cstruct" {>= "2.1.0"}
-  "ppx_tools"
+  "ppx_tools" {build}
   "mirage-types" {>= "2.8.0"}
-  "mirage-clock-unix" {>= "1.0.0"}
+  "mirage-clock-unix" {test & >= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}
   "mirage-flow" {test}


### PR DESCRIPTION
…ppx), mirage-clock-unix only for testing