### PR TITLE
Restore the previous call to `listen` in STACK.connect, and document it.

### DIFF
--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -104,7 +104,7 @@ struct
     with Not_found -> None
 
   let listen t =
-    Logs.debug (fun f -> f "Initializing listener for stack %a" pp t);
+    Logs.debug (fun f -> f "Establishing or updating listener for stack %a" pp t);
     Netif.listen t.netif (
       Ethif.input
         ~arpv4:(Arpv4.input t.arpv4)
@@ -140,6 +140,7 @@ struct
     let t = { id; netif; ethif; arpv4; ipv4; icmpv4; tcpv4; udpv4;
               udpv4_listeners; tcpv4_listeners } in
     Log.info (fun f -> f "stack assembled: %a" pp t);
+    Lwt.ignore_result (listen t);
     Lwt.return t
 
   let disconnect t =

--- a/lib/tcpip_stack_direct.mli
+++ b/lib/tcpip_stack_direct.mli
@@ -39,7 +39,13 @@ module Make
      and module IPV4 = Ipv4
      and module TCPV4 = Tcpv4
      and module UDPV4 = Udpv4
+
   val connect : netif V1_LWT.stackv4_config ->
     Ethif.t -> Arpv4.t -> Ipv4.t -> Icmpv4.t -> Udpv4.t -> Tcpv4.t ->
     t Lwt.t
+  (** [connect] assembles the arguments into a network stack, then calls
+      `listen` on the assembled stack before returning it to the caller.  The
+      initial `listen` functions to ensure that the lower-level layers (e.g.
+      ARP) are functioning, so that if the user wishes to establish outbound
+      connections, they will be able to do so. *)
 end


### PR DESCRIPTION
Requiring each caller to invoke `STACK.listen` is currently rather annoying, because there is no interface for any module that's passed a `STACK.t` to know whether what passed the `STACK.t` to it has called `listen` or not.  Restore the behavior that was removed in https://github.com/mirage/mirage-tcpip/commit/cccd214dcb5d3e8e17e07982317a02555780e704#diff-0089e4d851e40832017a323e072da706L180 , and attempt to do a better job of documenting it.  (A companion PR in the `mirage` repository will add more docstrings to the module type description for `V1.STACKV4`.)