### PR TITLE
renamed M_pp to M_util in mirage-types

### DIFF
--- a/lib/ethif/ethif.ml
+++ b/lib/ethif/ethif.ml
@@ -65,7 +65,7 @@ module Make(Netif : V1_LWT.NETWORK) = struct
     Netif.write t.netif frame >|= function
     | Ok () -> ()
     | Error e ->
-      Log.warn (fun f -> f "netif write errored %a" M_pp.pp_network_error e) ;
+      Log.warn (fun f -> f "netif write errored %a" M_util.pp_network_error e) ;
       ()
 
   (* XXX the error handling should be removed, and passed to the layer above *)
@@ -74,7 +74,7 @@ module Make(Netif : V1_LWT.NETWORK) = struct
     Netif.writev t.netif bufs >|= function
     | Ok () -> ()
     | Error e ->
-      Log.warn (fun f -> f "netif writev errored %a" M_pp.pp_network_error e) ;
+      Log.warn (fun f -> f "netif writev errored %a" M_util.pp_network_error e) ;
       ()
 
   let connect netif =

--- a/lib/tcpip_stack_direct.ml
+++ b/lib/tcpip_stack_direct.ml
@@ -129,7 +129,7 @@ struct
                    nstat.V1.Network.tx_bytes nstat.V1.Network.tx_pkts) ;
       Lwt.return_unit
     | Error e ->
-      Log.warn (fun p -> p "%a" M_pp.pp_network_error e) ;
+      Log.warn (fun p -> p "%a" M_util.pp_network_error e) ;
       (* XXX: error should be passed to the caller *)
       Lwt.return_unit
 


### PR DESCRIPTION
M_pp is a pretty bad name since I plan to move e.g. functions for Stats there (into submodules).  Thus rename early before we have too many dependencies... A travis build is good at https://github.com/mirage/mirage-dev/pull/208

To be merged with https://github.com/mirage/mirage/pull/666