### PR TITLE
resultify arp; kill ipv4 routing exception; tcp ignores route failures

### DIFF
--- a/lib/ipv4/static_ipv4.mli
+++ b/lib/ipv4/static_ipv4.mli
@@ -16,7 +16,6 @@
 
 module Make (N:V1_LWT.ETHIF) (A: V1_LWT.ARP) : sig
   include V1_LWT.IPV4 with type ethif = N.t
-  exception No_route_to_destination_address of Ipaddr.V4.t
   val connect :
     ?ip:Ipaddr.V4.t ->
     ?network:Ipaddr.V4.Prefix.t ->

--- a/lib/udp/udp.ml
+++ b/lib/udp/udp.ml
@@ -61,7 +61,14 @@ module Make(Ip: V1_LWT.IP) = struct
     let udp_header = Udp_packet.({ src_port; dst_port; }) in
     let udp_buf = Udp_packet.Marshal.make_cstruct udp_header ~pseudoheader:ph
             ~payload:(Cstruct.concat bufs) in
-    Ip.writev t.ip frame (udp_buf :: bufs) >|= Mirage_pp.reduce
+    Ip.writev t.ip frame (udp_buf :: bufs) >|= function
+    | Ok () as ok -> ok
+    | Error `Disconnected | Error `Unimplemented as e -> Mirage_pp.reduce e
+    | Error (`Msg _) as s -> s
+    | Error `No_route ->
+      let msg = Format.asprintf "failed to send packet to %a: no route" Ipaddr.pp_hum (Ip.to_uipaddr dst) in
+      Log.warn (fun f -> f "%s" msg);
+      Error (`Msg msg)
 
   let write ?src_port ~dst ~dst_port t buf =
     writev ?src_port ~dst ~dst_port t [buf]

--- a/lib_test/static_arp.ml
+++ b/lib_test/static_arp.ml
@@ -4,11 +4,10 @@ module Make(E : V1_LWT.ETHIF)(Clock : V1.MCLOCK) (Time : V1_LWT.TIME) = struct
   module A = Arpv4.Make(E)(Clock)(Time)
   (* generally repurpose A, but substitute input and query, and add functions
      for adding/deleting entries *)
-  type error = A.error
+  type error = V1.Arp.error
   type 'a io = 'a Lwt.t
   type buffer = Cstruct.t
   type macaddr = Macaddr.t
-  type result = A.result
   type ipaddr = Ipaddr.V4.t
   type repr = string
   
@@ -40,8 +39,8 @@ module Make(E : V1_LWT.ETHIF)(Clock : V1.MCLOCK) (Time : V1_LWT.TIME) = struct
   
   let query t ip =
     match Hashtbl.mem t.table ip with
-    | false -> Lwt.return `Timeout
-    | true -> Lwt.return (`Ok (Hashtbl.find t.table ip))
+    | false -> Lwt.return @@ Error `Timeout
+    | true -> Lwt.return (Ok (Hashtbl.find t.table ip))
   
   let input t buffer =
     (* disregard responses, but reply to queries *)


### PR DESCRIPTION
Include `No_route` as a possible error from `Static_ipv4` and `Ipv6` `write`
functions.  (Requires https://github.com/mirage/mirage/pull/711 or a change like it.)

If `Error No_route` is returned from a write function invoked by
lib/tcp/wire.ml (in other words, when sending a TCP packet), proceed as
if the write had succeeded, allowing TCP's normal timeouts and recovery
to attempt to restore the connection.

Removes the hated `exception No_route_to_destination_address of Ipaddr.V4.t`.

Fixes #240.