### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/examples/services.ml
+++ b/examples/services.ml
@@ -1,7 +1,7 @@
 open Lwt
-open V1_LWT
+open Mirage_types_lwt
 
-module Main (C: V1_LWT.CONSOLE) (S: V1_LWT.STACKV4) = struct
+module Main (C: Mirage_types_lwt.CONSOLE) (S: Mirage_types_lwt.STACKV4) = struct
   let report_and_close c flow message =
     C.log c message;
     S.TCPV4.close flow


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.