### PR TITLE
Reinstate Random.float in calculate_reachable_time

### DIFF
--- a/lib/ipv6/ndpv6.ml
+++ b/lib/ipv6/ndpv6.ml
@@ -142,7 +142,7 @@ let multicast_mac =
 (* vary the reachable time by some random factor between 0.5 and 1.5 *)
 let compute_reachable_time reachable_time =
   let factor =
-    Defaults.(min_random_factor +. (max_random_factor -. min_random_factor))
+    Defaults.(min_random_factor +. Random.float (max_random_factor -. min_random_factor))
   in
   Int64.of_float (factor *. Int64.to_float reachable_time)
 


### PR DESCRIPTION
This is a typo fix in the _Reachable Time_ calculation's factor.

It currently lacks a call to `Random.float`:

  - it existed in 016c00f
  - and was removed in 80dbfcd
