### PR TITLE
Fix various parsing bugs in tcpip

### DIFF
--- a/lib/ipv4/ipv4_common.ml
+++ b/lib/ipv4/ipv4_common.ml
@@ -25,10 +25,10 @@ let allocate_frame ~src ~source ~(dst:Ipaddr.V4.t) ~(proto : [`ICMP | `TCP | `UD
     let ipv4_header = Ipv4_packet.({options = Cstruct.create 0;
                                     src; dst; ttl = 38; 
                                     proto = Ipv4_packet.Marshal.protocol_to_int proto; }) in
-    (* set the payload to 0, since we don't know what it'll be yet *)
+    (* set the payload_len to 0, since we don't know what it'll be yet *)
     (* the caller needs to then use [writev] or [write] to output the buffer;
        otherwise length, id, and checksum won't be set properly *)
-    match Ipv4_packet.Marshal.into_cstruct ~payload:(Cstruct.create 0) ipv4_header buf with
+    match Ipv4_packet.Marshal.into_cstruct ~payload_len:0 ipv4_header buf with
     | Error _s ->
       raise (Invalid_argument "writing ipv4 header to ipv4.allocate_frame failed")
     | Ok () ->

--- a/lib/ipv4/ipv4_packet.ml
+++ b/lib/ipv4/ipv4_packet.ml
@@ -125,8 +125,13 @@ module Unmarshal = struct
         if options_end > sizeof_ipv4 then (Cstruct.sub buf sizeof_ipv4 (options_end - sizeof_ipv4))
         else (Cstruct.create 0)
       in
-      let payload = Cstruct.sub buf options_end payload_len in
-      Result.Ok ({src; dst; proto; ttl; options;}, payload)
+      let payload_available = Cstruct.len buf - options_end in
+      if payload_available < payload_len then (
+        Error (Printf.sprintf "Payload buffer (%d bytes) too small to contain payload (of size %d from header)" payload_available payload_len)
+      ) else (
+        let payload = Cstruct.sub buf options_end payload_len in
+        Ok ({src; dst; proto; ttl; options;}, payload)
+      )
     in
     size_check buf >>= check_version >>= get_header_length >>= parse buf
 

--- a/lib/ipv4/ipv4_packet.ml
+++ b/lib/ipv4/ipv4_packet.ml
@@ -15,7 +15,12 @@ let pp fmt t =
   Format.fprintf fmt "IPv4 packet %a -> %a: proto %d, ttl %d, options %a"
     Ipaddr.V4.pp_hum t.src Ipaddr.V4.pp_hum t.dst t.proto t.ttl Cstruct.hexdump_pp t.options
 
-let equal p q = (p = q)
+let equal {src; dst; proto; ttl; options} q =
+  src = q.src &&
+  dst = q.dst &&
+  proto = q.proto &&
+  ttl = q.ttl &&
+  Cstruct.equal options q.options
 
 module Marshal = struct
   open Ipv4_wire

--- a/lib/ipv4/ipv4_packet.ml
+++ b/lib/ipv4/ipv4_packet.ml
@@ -55,7 +55,7 @@ module Marshal = struct
     set_ipv4_src buf (Ipaddr.V4.to_int32 t.src);
     set_ipv4_dst buf (Ipaddr.V4.to_int32 t.dst);
     Cstruct.blit t.options 0 buf sizeof_ipv4 (Cstruct.len t.options);
-    set_ipv4_len buf (sizeof_ipv4 + (options_len / 4) + payload_len);
+    set_ipv4_len buf (sizeof_ipv4 + options_len + payload_len);
     let checksum = Tcpip_checksum.ones_complement @@ Cstruct.sub buf 0 (20 + options_len) in
     set_ipv4_csum buf checksum
 

--- a/lib/ipv4/ipv4_packet.mli
+++ b/lib/ipv4/ipv4_packet.mli
@@ -34,17 +34,16 @@ module Marshal : sig
     -> int -> Cstruct.t
     (** [pseudoheader src dst proto len] constructs a pseudoheader, suitable for inclusion in transport-layer checksum calculations, including the information supplied.  [len] should be the total length of the transport-layer header and payload.  *)
 
-(** [into_cstruct ~payload t buf] attempts to write a header representing [t] (including
-    [t.options], but not [payload]  into [buf]
-    at offset 0.  If there is insufficient space to represent [t], an error will
-    be returned. *)
-  val into_cstruct : payload:Cstruct.t -> t -> Cstruct.t -> (unit, error) Result.result
+(** [into_cstruct ~payload_len t buf] attempts to write a header representing [t] (including
+    [t.options]) into [buf] at offset 0.
+    If there is insufficient space to represent [t], an error will be returned. *)
+  val into_cstruct : payload_len:int -> t -> Cstruct.t -> (unit, error) Result.result
 
-  (** [make_cstruct ~payload t] allocates, fills, and returns a buffer
+  (** [make_cstruct ~payload_len t] allocates, fills, and returns a buffer
       repesenting the IPV4 header corresponding to [t].
       If [t.options] is non-empty, [t.options] will be
       concatenated onto the result. A variable amount of memory (at least 20 bytes
-      for a zero-length options field) will be allocated, but [t.payload] is not
-      represented in the output. *)
-  val make_cstruct : payload:Cstruct.t -> t -> Cstruct.t
+      for a zero-length options field) will be allocated.
+      Note: no space is allocated for the payload. *)
+  val make_cstruct : payload_len:int -> t -> Cstruct.t
 end

--- a/lib/tcp/options.ml
+++ b/lib/tcp/options.ml
@@ -99,6 +99,7 @@ let unmarshal buf =
       | Ok items, Ok item -> Ok (item :: items)
       | _, Error s | Error s, _ -> Error s
     ) i (Ok [])
+  |> Rresult.R.map List.rev
 
 let size_of_option = function
   | Noop -> 1
@@ -205,8 +206,4 @@ let pp fmt = function
   | Timestamp (a,b)     -> pf fmt "Timestamp(%lu,%lu)" a b
   | Unknown (t,_)       -> pf fmt "%d?" t
 
-let pps fmt = function
-  | [] -> pf fmt "[]"
-  | x  ->
-    let ppl fmt x = Format.pp_print_list pp fmt x in
-    pf fmt "[ %a ]" ppl x
+let pps = Fmt.Dump.list pp

--- a/lib/tcp/tcp_packet.ml
+++ b/lib/tcp/tcp_packet.ml
@@ -133,7 +133,6 @@ module Marshal = struct
     let options_len = Options.marshal options_buf t.options in
     let options_buf = Cstruct.set_len options_buf options_len in
     let buf = Cstruct.create sizeof_tcp in
-    Cstruct.memset buf 0x00; (* remove when Cstruct gives zero'd buffers by default*)
     unsafe_fill ~pseudoheader ~payload t buf options_len;
     Cstruct.concat [buf; options_buf]
 end

--- a/lib/tcp/tcp_packet.ml
+++ b/lib/tcp/tcp_packet.ml
@@ -102,9 +102,9 @@ module Marshal = struct
       else Ok ()
     in
     let check_overall_len header_length =
-      if (Cstruct.len buf) < ((Cstruct.len payload) + header_length) then
-        Error (Printf.sprintf "Not enough space for header and payload: %d < %d"
-                 (Cstruct.len buf) (Cstruct.len payload + header_length))
+      if (Cstruct.len buf) < header_length then
+        Error (Printf.sprintf "Not enough space for TCP header: %d < %d"
+                 (Cstruct.len buf) header_length)
       else Ok ()
     in
     let insert_options options_frame =

--- a/lib/tcp/tcp_packet.ml
+++ b/lib/tcp/tcp_packet.ml
@@ -41,7 +41,7 @@ module Unmarshal = struct
     in
     let options data_offset pkt =
       if data_offset > 20 then
-        Options.unmarshal (Cstruct.shift pkt sizeof_tcp)
+        Options.unmarshal (Cstruct.sub pkt sizeof_tcp (data_offset - sizeof_tcp))
       else if data_offset < 20 then
         Result.Error "data offset was unreasonably short; TCP header can't be valid"
       else (Ok [])

--- a/lib/udp/udp_packet.ml
+++ b/lib/udp/udp_packet.ml
@@ -62,10 +62,10 @@ module Marshal = struct
       else Ok ()
     in
     let check_overall_len () =
-      let needed = (Cstruct.len payload) + sizeof_udp in
+      let needed = sizeof_udp in
       let provided = Cstruct.len udp_buf in
       if provided < needed then
-        Error (Printf.sprintf "Not enough space for header and payload: provided %d, need %d" provided needed)
+        Error (Printf.sprintf "Not enough space for UDP header: provided %d, need %d" provided needed)
       else Ok ((Cstruct.len payload) + sizeof_udp)
     in
     check_header_len () >>= check_overall_len >>= fun len ->

--- a/lib_test/common.ml
+++ b/lib_test/common.ml
@@ -24,7 +24,9 @@ let cstruct =
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)
 
+let ipv4_packet = (module Ipv4_packet : Alcotest.TESTABLE with type t = Ipv4_packet.t)
 let udp_packet = (module Udp_packet : Alcotest.TESTABLE with type t = Udp_packet.t)
+let tcp_packet = (module Tcp.Tcp_packet : Alcotest.TESTABLE with type t = Tcp.Tcp_packet.t)
 
 let sequence =
   let module M = struct

--- a/lib_test/common.ml
+++ b/lib_test/common.ml
@@ -24,7 +24,7 @@ let cstruct =
   end in
   (module M : Alcotest.TESTABLE with type t = M.t)
 
-let packet = (module Udp_packet : Alcotest.TESTABLE with type t = Udp_packet.t)
+let udp_packet = (module Udp_packet : Alcotest.TESTABLE with type t = Udp_packet.t)
 
 let sequence =
   let module M = struct

--- a/lib_test/test_ip_options.ml
+++ b/lib_test/test_ip_options.ml
@@ -32,14 +32,12 @@ let test_size () =
   let dst = Ipaddr.V4.of_string_exn "127.0.0.2" in
   let ttl = 64 in
   let ip = { Ipv4_packet.src; dst; proto = 17; ttl; options = (Cstruct.of_string "aaaa") } in
-  let tmp = Ipv4_packet.Marshal.make_cstruct ~payload_len:100 ip in
-  let tmp = Cstruct.concat [tmp; Cstruct.create 100] in
-  Printf.printf "len = %d\n" (Cstruct.len tmp);
-  match Ipv4_packet.Unmarshal.of_cstruct tmp with
-  | Error x -> failwith x
-  | Ok (loaded, _) ->
-    assert (Ipv4_packet.equal ip loaded);
-    Lwt.return_unit
+  let payload = Cstruct.of_string "abcdefgh" in
+  let tmp = Ipv4_packet.Marshal.make_cstruct ~payload_len:(Cstruct.len payload) ip in
+  let tmp = Cstruct.concat [tmp; payload] in
+  Ipv4_packet.Unmarshal.of_cstruct tmp
+  |> Alcotest.(check (result (pair Common.ipv4_packet Common.cstruct) string)) "Loading an IP packet with IP options" (Ok (ip, payload));
+  Lwt.return_unit
 
 let suite = [
   "unmarshal ip datagram with options", `Quick, test_unmarshal_with_options;

--- a/lib_test/test_tcp_options.ml
+++ b/lib_test/test_tcp_options.ml
@@ -196,6 +196,11 @@ let test_marshal_into_cstruct () =
   Alcotest.check Alcotest.int "size of options buf" options_size @@ Tcp.Options.marshal just_options options;
   (* expecting the result of Options.Marshal to be here *)
   Alcotest.check Common.cstruct "marshalled options are as expected" just_options generated_options;
+  (* Now try with make_cstruct *)
+  let headers = Tcp.Tcp_packet.Marshal.make_cstruct ~pseudoheader ~payload packet in
+  let raw =Cstruct.concat [headers; payload]  in
+  Ipv4_packet.Unmarshal.verify_transport_checksum ~proto:`TCP ~ipv4_header ~transport_packet:raw
+  |> Alcotest.(check bool) "Checksum correct" true;
   Lwt.return_unit
 
 let suite = [

--- a/opam
+++ b/opam
@@ -44,7 +44,7 @@ depends: [
   "ocamlbuild" {build}
   "result"
   "rresult"
-  "cstruct" {>= "2.1.0"}
+  "cstruct" {>= "2.2.0"}
   "ppx_tools" {build}
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}


### PR DESCRIPTION
They were checking that the buffer was big enough for the headers and
the payload, but they don't write the payload and there's no reason to
require it to be written to the same buffer.

Also, change the IPv4 marshal functions to take the payload length
rather than the payload itself, so that the caller can provide the
payload in multiple buffers. This also makes it clear that the function
does not actually write the payload.