### PR TITLE
remove pins for mirage-protocols{-lwt}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ script: bash -ex .travis-ci.sh
 sudo: required
 env:
   global:
-  - PINS="mirage-protocols-lwt mirage-protocols" #needed for Ethernet.mtu, can be removed once mirage-protocols > 1.0.0 is released
-  matrix: 
+  matrix:
   - OCAML_VERSION=4.03 PACKAGE=tcpip MIRAGE_MODE=unix
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.03 PACKAGE=tcpip MIRAGE_MODE=xen
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.04 PACKAGE=tcpip MIRAGE_MODE=ukvm


### PR DESCRIPTION
The new versions have been released into opam-repository (https://github.com/ocaml/opam-repository/pull/8612) .