### PR TITLE
unbreak TCP

### DIFF
--- a/lib/tcp/window.ml
+++ b/lib/tcp/window.ml
@@ -59,6 +59,7 @@ type t = {
 let count_ackd_segs = MProf.Counter.make ~name:"tcp-ackd-segs"
 
 let default_mss = 536
+let max_mss = 1460
 
 (* To string for debugging *)
 let pp fmt t =
@@ -77,7 +78,7 @@ let t ~rx_wnd_scale ~tx_wnd_scale ~rx_wnd ~tx_wnd ~rx_isn ~tx_mss ~tx_isn =
   let rx_nxt = Sequence.incr rx_isn in
   let rx_nxt_inseq = Sequence.incr rx_isn in
   (* TODO: improve this sanity check of tx_mss *)
-  let tx_mss = match tx_mss with |None -> default_mss |Some mss -> mss in
+  let tx_mss = match tx_mss with |None -> default_mss |Some mss -> min mss max_mss in
   let snd_una = tx_nxt in
   let fast_rec_th = tx_nxt in
   let ack_serviced = true in


### PR DESCRIPTION
a recently introduced change (#288) breaks the TCP part of this library by sending out segments which are bigger than the mtu.  this patch reverts parts of that patch (sorry, I don't have energy or time to dig deeper how to 'properly' fix it).  I discovered the breakage when updating several unikernels to use tcpip-3.x, and run into assertion failures (https://github.com/Solo5/solo5/blob/v0.2.2/kernel/virtio/virtio_net.c#L123) (but only after some hours when someone with a strange tcpip stack (read: window size above 1460) came along).  I use this patched tcpip since ~1 week without any assertion failures.