### PR TITLE
remove unused pattern match in tcp writes

### DIFF
--- a/lib/tcp/pcb.ml
+++ b/lib/tcp/pcb.ml
@@ -603,12 +603,6 @@ struct
           | Error (`No_route _s) ->
             (* normal mechanism for recovery is fine *)
             connecttimer t id tx_isn options window (count + 1)
-          | Error e ->
-            (* TODO: possibly the more sensible thing to do is give up *)
-            Log.warn (fun f ->
-                f "Error sending initial SYN in TCP connection: %a"
-                  WIRE.pp_error e);
-            connecttimer t id tx_isn options window (count + 1)
         )
       else Lwt.return_unit
 
@@ -641,11 +635,6 @@ struct
     | Ok () | Error (`No_route _) (* keep trying *) ->
       Lwt.async (fun () -> connecttimer t id tx_isn options window 0);
       th
-    | Error e ->
-      Log.warn (fun f ->
-          f "Failure sending initial SYN in outgoing connection: %a"
-            WIRE.pp_error e);
-      Lwt.return @@ Error (e :> error)
 
   (* Construct the main TCP thread *)
   let create ip clock =

--- a/opam
+++ b/opam
@@ -63,7 +63,7 @@ depends: [
   "pcap-format" {test}
   "mirage-clock-unix" {test & >= "1.2.0"}
   "fmt"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.4.7" & < "3.0.0" }
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"


### PR DESCRIPTION
`No_route` is now the only error variant, so these cases were not used:

```
File "lib/tcp/pcb.ml", line 606, characters 12-19:
Warning 11: this match case is unused.
File "lib/tcp/pcb.ml", line 644, characters 6-13:
Warning 11: this match case is unused.
```

Remove them.