### PR TITLE
Test mtus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script: bash -ex .travis-ci.sh
 sudo: required
 env:
   global:
-  - EXTRA_REMOTES="https://github.com/djs55/mirage-dev.git#fix-revdeps"
+  - EXTRA_REMOTES="https://github.com/djs55/mirage-dev.git#fix-revdeps" PINS="mirage-vnetif:https://github.com/yomimono/mirage-vnetif.git#mtu-enforcing-netifs"
   matrix:
   - OCAML_VERSION=4.03 PACKAGE=tcpip MIRAGE_MODE=unix
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.03 PACKAGE=tcpip MIRAGE_MODE=xen

--- a/lib/tcp/pcb.ml
+++ b/lib/tcp/pcb.ml
@@ -266,12 +266,15 @@ struct
       rx_wnd_scaleoffer: int }
 
   let new_pcb t params id =
+    let mtu_mss = Ip.mtu t.ip - Tcp_wire.sizeof_tcp in
     let { tx_wnd; sequence; options; tx_isn; rx_wnd; rx_wnd_scaleoffer } =
       params
     in
     let tx_mss = List.fold_left (fun a ->
-        function Options.MSS m -> Some m | _ -> a
-      ) None options
+      function
+      | Options.MSS m -> min m mtu_mss
+      | _ -> a
+    ) mtu_mss options
     in
     let (rx_wnd_scale, tx_wnd_scale), opts =
       resolve_wnd_scaling options rx_wnd_scaleoffer

--- a/lib/tcp/window.ml
+++ b/lib/tcp/window.ml
@@ -58,9 +58,6 @@ type t = {
 
 let count_ackd_segs = MProf.Counter.make ~name:"tcp-ackd-segs"
 
-let default_mss = 536
-let max_mss = 1460
-
 (* To string for debugging *)
 let pp fmt t =
   Format.fprintf fmt
@@ -77,8 +74,6 @@ let t ~rx_wnd_scale ~tx_wnd_scale ~rx_wnd ~tx_wnd ~rx_isn ~tx_mss ~tx_isn =
   let tx_nxt = tx_isn in
   let rx_nxt = Sequence.incr rx_isn in
   let rx_nxt_inseq = Sequence.incr rx_isn in
-  (* TODO: improve this sanity check of tx_mss *)
-  let tx_mss = match tx_mss with |None -> default_mss |Some mss -> min mss max_mss in
   let snd_una = tx_nxt in
   let fast_rec_th = tx_nxt in
   let ack_serviced = true in

--- a/lib/tcp/window.mli
+++ b/lib/tcp/window.mli
@@ -19,7 +19,7 @@ type t
 val pp: Format.formatter -> t -> unit
 
 val t : rx_wnd_scale:int -> tx_wnd_scale:int -> rx_wnd:int ->
-  tx_wnd:int -> rx_isn:Sequence.t -> tx_mss:int option -> tx_isn:Sequence.t -> t
+  tx_wnd:int -> rx_isn:Sequence.t -> tx_mss:int -> tx_isn:Sequence.t -> t
 
 val valid : t -> Sequence.t -> bool
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -23,6 +23,7 @@ let suite = [
   "udp"            , Test_udp.suite         ;
   "tcp_window"     , Test_tcp_window.suite  ;
   "tcp_options"    , Test_tcp_options.suite ;
+  "mtu+tcp"        , Test_mtus.suite        ;
   "rfc5961"        , Test_rfc5961.suite     ;
   "socket"         , Test_socket.suite      ;
   "connect"        , Test_connect.suite     ;

--- a/lib_test/test_mtus.ml
+++ b/lib_test/test_mtus.ml
@@ -1,0 +1,129 @@
+open Lwt.Infix
+
+module Server = struct
+  let ip = Ipaddr.V4.of_string_exn "192.168.1.254"
+  let netmask = 24
+  let gateway = None
+end
+
+module Client = struct
+  let ip = Ipaddr.V4.of_string_exn "192.168.1.10"
+  let netmask = 24
+  let gateway = None
+end
+
+let server_port = 7
+
+module Backend = Vnetif_backends.Mtu_enforced
+module Stack = Vnetif_common.VNETIF_STACK(Backend)
+
+let default_mtu = 1500
+
+let err_fail e =
+  let err = Format.asprintf "%a" Stack.Stackv4.TCPV4.pp_error e in
+  Alcotest.fail err
+
+let write_err_fail e =
+  let err = Format.asprintf "%a" Stack.Stackv4.TCPV4.pp_write_error e in
+  Alcotest.fail err
+
+let rec read_all flow so_far =
+  Stack.Stackv4.TCPV4.read flow >>= function
+  | Error e -> err_fail e
+  | Ok `Eof -> Lwt.return @@ List.rev so_far
+  | Ok (`Data s) -> read_all flow (s :: so_far)
+
+let read_one flow =
+  Stack.Stackv4.TCPV4.read flow >>= function
+  | Error e -> err_fail e
+  | Ok `Eof -> Alcotest.fail "received EOF when we expected at least some data from read"
+  | Ok (`Data s) -> Lwt.return s
+
+let get_stacks ?client_mtu ?server_mtu backend =
+  let or_default = function | None -> default_mtu | Some n -> n in
+  let client_mtu, server_mtu = or_default client_mtu, or_default server_mtu in
+  Client.(Stack.create_stack backend ~mtu:client_mtu ip netmask gateway) >>= fun client ->
+  Server.(Stack.create_stack backend ~mtu:server_mtu ip netmask gateway) >>= fun server ->
+  let max_mtu = max client_mtu server_mtu in
+  Backend.set_mtu max_mtu;
+  Lwt.return (server, client)
+
+let start_server ~f server =
+  Stack.Stackv4.listen_tcpv4 server ~port:server_port f;
+  Stack.Stackv4.listen server
+
+let start_client client =
+  Stack.Stackv4.TCPV4.create_connection (Stack.Stackv4.tcpv4 client) (Server.ip, server_port) >>= function
+  | Ok connection -> Lwt.return connection
+  | Error e -> err_fail e
+
+let connect () =
+  let backend = Backend.create () in
+  get_stacks ~server_mtu:9000 backend >>= fun (server, client) ->
+  Lwt.async (fun () -> start_server ~f:(fun _ -> Lwt.return_unit) server);
+  start_client client >>= fun flow ->
+    Stack.Stackv4.TCPV4.close flow
+
+let big_server_response () =
+  let response = Cstruct.create 7000 in
+  Cstruct.memset response 255;
+  let backend = Backend.create () in
+  get_stacks ~client_mtu:1500 ~server_mtu:9000 backend >>= fun (server, client) ->
+  let f flow =
+    Stack.Stackv4.TCPV4.write flow response >>= function
+    | Error e -> write_err_fail e
+    | Ok () -> Stack.Stackv4.TCPV4.close flow
+  in
+  Lwt.async (fun () -> start_server ~f server);
+  start_client client >>= fun flow -> read_all flow [] >>= fun l ->
+  Alcotest.(check int) "received size matches sent size" (Cstruct.len response) (Cstruct.len (Cstruct.concat l));
+  Stack.Stackv4.TCPV4.close flow
+
+let big_client_request_chunked () =
+  let request = Cstruct.create 3750 in
+  Cstruct.memset request 255;
+  let backend = Backend.create () in
+  get_stacks ~client_mtu:1500 ~server_mtu:9000 backend >>= fun (server, client) ->
+  let f flow =
+    Stack.Stackv4.TCPV4.write flow request >>= function
+    | Error e -> write_err_fail e
+    | Ok () -> Stack.Stackv4.TCPV4.close flow
+  in
+  Lwt.async (fun () -> start_server ~f:(fun _flow -> Lwt.return_unit) server);
+  start_client client >>= f
+
+let big_server_response_not_chunked () =
+  let response = Cstruct.create 7000 in
+  Cstruct.memset response 255;
+  let backend = Backend.create () in
+  get_stacks ~client_mtu:9000 ~server_mtu:9000 backend >>= fun (server, client) ->
+  let f flow =
+    Stack.Stackv4.TCPV4.write flow response >>= function
+    | Error e -> write_err_fail e
+    | Ok () -> Stack.Stackv4.TCPV4.close flow
+  in
+  Lwt.async (fun () -> start_server ~f server);
+  start_client client >>= fun flow -> read_one flow >>= fun buf ->
+  Alcotest.(check int) "received size matches sent size" (Cstruct.len response) (Cstruct.len buf);
+  Stack.Stackv4.TCPV4.close flow
+
+let long_comms amt timeout () =
+  (* use the iperf tests to test long-running communication between
+   * the two stacks with their different link settings.
+   * this helps us find bugs in situations like the TCP window expanding
+   * to be larger than the MTU, and the implementation failing to 
+   * limit the size of the sent packet in that case. *)
+  let module Test = Test_iperf.Test_iperf(Backend) in
+  let backend = Backend.create () in
+  get_stacks ~client_mtu:1500 ~server_mtu:9000 backend >>= fun (server, client) ->
+  Test.V.record_pcap backend
+    (Printf.sprintf "tests/pcap/tcp_mtus_long_comms_%d.pcap" amt)
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let suite = [
+  "connections work", `Quick, connect;
+  "large server responses are received", `Quick, big_server_response;
+  "large client requests are chunked properly", `Quick, big_client_request_chunked;
+  "large messages aren't unnecessarily segmented", `Quick, big_server_response_not_chunked;
+  "iperf test doesn't crash", `Quick, long_comms Test_iperf.amt_quick 120.0;
+]

--- a/lib_test/test_tcp_window.ml
+++ b/lib_test/test_tcp_window.ml
@@ -20,7 +20,7 @@ end
 module Timed_window = Tcp.Window.Make(Clock)
 
 let default_window () =
-  Tcp.Window.t ~tx_wnd_scale:2 ~rx_wnd_scale:2 ~rx_wnd:65535 ~tx_wnd:65535 ~rx_isn:Tcp.Sequence.zero ~tx_mss:(Some 1460) ~tx_isn:Tcp.Sequence.zero
+  Tcp.Window.t ~tx_wnd_scale:2 ~rx_wnd_scale:2 ~rx_wnd:65535 ~tx_wnd:65535 ~rx_isn:Tcp.Sequence.zero ~tx_mss:1460 ~tx_isn:Tcp.Sequence.zero
 
 let fresh_window () =
   let window = default_window () in


### PR DESCRIPTION
The first commit adds tests for the interaction between the TCP implementation 
and the MTU reported by the IP module over which TCP is parameterized.
The following tests (along with some necessary infrastructure and refactoring) are added:

* stacks with different MTUs can connect via TCP
* stacks with different MTUs can make it through the iperf tests
* calls to TCP.write with Cstruct.t's > MTU don't result in attempted
  sends of Ethernet frames larger than the MTU
* calls to TCP.write with large Cstruct.t's don't violate the other
  side's signaled MSS
* calls to TCP.write with large Cstruct.t's don't send multiple small
  Ethernet frames when both sides have large MTUs and MSSs

A subset of tests in the first commit fail on tcpip 3.1.0 and 3.1.1 (excessively large packets can be sent).  A subset of tests in the first commit fail on tcpip 3.1.2 (excessively small packets are sent when both sides could send larger ones).

The second commit causes all tests to pass.

The tests require the third commit, a pin of a branch of [mirage-vnetif](https://github.com/yomimono/mirage-vnetif/tree/mtu-enforcing-netifs) which fails when `write` is called on a virtual network interface with data larger than the interface can write.