### PR TITLE
s/cstruct.lwt/cstruct-lwt/ (followon #323)

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -3,12 +3,12 @@
 wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 bash -ex .travis-opam.sh
 
-# try building mirage-www in Unix and Xen modes
+# try building mirage-www in the mode set by the build matrix
 
 export OPAMYES=1
 eval `opam config env`
 
-git clone -b mirage-dev git://github.com/mirage/mirage-www
+git clone -b master git://github.com/mirage/mirage-www
 cd mirage-www
 git log --oneline |head -5
 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -5,14 +5,14 @@ bash -ex .travis-opam.sh
 
 # try building mirage-www in the mode set by the build matrix
 
-export OPAMYES=1
-eval `opam config env`
+#export OPAMYES=1
+#eval `opam config env`
 
-git clone -b master git://github.com/mirage/mirage-www
-cd mirage-www
-git log --oneline |head -5
+#git clone -b master git://github.com/mirage/mirage-www
+#cd mirage-www
+#git log --oneline |head -5
 
-opam install mirage
-make MODE=$MIRAGE_MODE configure
-make MODE=$MIRAGE_MODE depend
-make MODE=$MIRAGE_MODE build
+#opam install mirage
+#make MODE=$MIRAGE_MODE configure
+#make MODE=$MIRAGE_MODE depend
+#make MODE=$MIRAGE_MODE build

--- a/src/stack-unix/jbuild
+++ b/src/stack-unix/jbuild
@@ -4,39 +4,39 @@
   (public_name tcpip.icmpv4-socket)
   (modules icmpv4_socket)
   (wrapped false)
-  (libraries (lwt.unix ipaddr.unix cstruct.lwt io-page-unix tcpip.icmpv4 tcpip.ipv4 tcpip.ipv6 mirage-protocols-lwt))))
+  (libraries (lwt.unix ipaddr.unix cstruct-lwt io-page-unix tcpip.icmpv4 tcpip.ipv4 tcpip.ipv6 mirage-protocols-lwt))))
 
 (library
  ((name udpv4_socket)
   (public_name tcpip.udpv4-socket)
   (modules udpv4_socket)
   (wrapped false)
-  (libraries (lwt.unix ipaddr.unix cstruct.lwt fmt mirage-protocols-lwt))))
+  (libraries (lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols-lwt))))
 
 (library
  ((name udpv6_socket)
   (public_name tcpip.udpv6-socket)
   (modules udpv6_socket)
   (wrapped false)
-  (libraries (lwt.unix ipaddr.unix cstruct.lwt fmt mirage-protocols-lwt))))
+  (libraries (lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols-lwt))))
 
 (library
  ((name tcpv4_socket)
   (public_name tcpip.tcpv4-socket)
   (modules (tcpv4_socket tcp_socket))
   (wrapped false)
-  (libraries (lwt.unix ipaddr.unix cstruct.lwt fmt mirage-protocols-lwt))))
+  (libraries (lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols-lwt))))
 
 (library
  ((name tcpv6_socket)
   (public_name tcpip.tcpv6-socket)
   (modules (tcpv6_socket))
   (wrapped false)
-  (libraries (lwt.unix ipaddr.unix cstruct.lwt fmt mirage-protocols-lwt tcpv4_socket))))
+  (libraries (lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols-lwt tcpv4_socket))))
 
 (library
  ((name tcpip_stack_socket)
   (public_name tcpip.stack-socket)
   (modules (tcpip_stack_socket ipv4_socket ipv6_socket))
   (wrapped false)
-  (libraries (lwt.unix cstruct.lwt ipaddr.unix io-page-unix logs tcpip.ipv4 tcpip.ipv6 tcpip.icmpv4 mirage-protocols-lwt mirage-stack-lwt))))
+  (libraries (lwt.unix cstruct-lwt ipaddr.unix io-page-unix logs tcpip.ipv4 tcpip.ipv6 tcpip.icmpv4 mirage-protocols-lwt mirage-stack-lwt))))


### PR DESCRIPTION
Change the dependency expression in `stack-unix` to ask for the extant `cstruct-lwt` instead of `cstruct.lwt`.

Also, don't attempt to test `tcpip` by building `mirage-www` anymore, because https://github.com/mirage/mirage-www/pull/561 is still pending.  Once `mirage-www` is again buildable, tests which build the site on *all* backends (not just Unix, Xen, and Ukvm) should be added.

Fixes #321 