### PR TITLE
use current mirage-www master for test, not an old branch

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -3,12 +3,12 @@
 wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 bash -ex .travis-opam.sh
 
-# try building mirage-www in Unix and Xen modes
+# try building mirage-www in the mode set by the build matrix
 
 export OPAMYES=1
 eval `opam config env`
 
-git clone -b mirage-dev git://github.com/mirage/mirage-www
+git clone -b master git://github.com/mirage/mirage-www
 cd mirage-www
 git log --oneline |head -5
 


### PR DESCRIPTION
I didn't set this back after preparing MirageOS 3.  The `mirage-dev` branch of `mirage-www` is now 66 commits behind and certainly not helping us have useful tests when referenced here.