### PR TITLE
Improve Tcp.Wire module

### DIFF
--- a/src/tcp/wire.ml
+++ b/src/tcp/wire.ml
@@ -27,26 +27,26 @@ module Make (Ip:Mirage_protocols_lwt.IP) = struct
 
   let pp_error = Mirage_protocols.Ip.pp_error
 
-  type id = {
+  type t = {
     dst_port: int;             (* Remote TCP port *)
     dst: Ip.ipaddr;            (* Remote IP address *)
     src_port: int;             (* Local TCP port *)
     src: Ip.ipaddr;            (* Local IP address *)
   }
 
-  let wire ~src ~src_port ~dst ~dst_port =
-    { dst_port ; dst ; src_port ; src }
+  let v ~src ~src_port ~dst ~dst_port = { dst_port ; dst ; src_port ; src }
 
-  let src_port_of_id id = id.src_port
+  let src t = t.src
+  let dst t = t.dst
+  let src_port t = t.src_port
+  let dst_port t = t.dst_port
 
-  let dst_of_id id = (id.dst, id.dst_port)
-
-  let pp_id fmt id =
+  let pp ppf t =
     let uip = Ip.to_uipaddr in
-    Format.fprintf fmt "remote %a,%d to local %a, %d"
-      Ipaddr.pp_hum (uip id.dst) id.dst_port Ipaddr.pp_hum (uip id.src) id.src_port
+    Fmt.pf ppf "remote %a,%d to local %a, %d"
+      Ipaddr.pp_hum (uip t.dst) t.dst_port Ipaddr.pp_hum (uip t.src) t.src_port
 
-  let xmit ~ip ~id:{ src_port; dst_port; dst; _ } ?(rst=false) ?(syn=false)
+  let xmit ~ip { src_port; dst_port; dst; _ } ?(rst=false) ?(syn=false)
       ?(fin=false) ?(psh=false)
       ~rx_ack ~seq ~window ~options payload
     =

--- a/src/tcp/wire.mli
+++ b/src/tcp/wire.mli
@@ -16,26 +16,41 @@
 
 open Result
 
-module Make(Ip:Mirage_protocols_lwt.IP) : sig
+module Make (Ip:Mirage_protocols_lwt.IP) : sig
 
   type error = Mirage_protocols.Ip.error
+  (** The type for TCP wire errors. *)
 
   val pp_error: error Fmt.t
+  (** [pp_error] is the pretty-printer for TCP wire {!error}s. *)
 
-  type id
+  type t
+  (** The type for TCP wire values. *)
 
-  val src_port_of_id : id -> int
+  val pp: t Fmt.t
+  (** [pp] is the pretty-printer for TCP wire values. *)
 
-  val dst_of_id : id -> (Ip.ipaddr * int)
+  val dst_port : t -> int
+  (** Remote TCP port *)
 
-  val wire : src:Ip.ipaddr -> src_port:int -> dst:Ip.ipaddr -> dst_port:int -> id
+  val dst: t -> Ip.ipaddr
+  (** Remote IP address *)
 
-  val pp_id : Format.formatter -> id -> unit
+  val src_port : t -> int
+  (** Local TCP port *)
 
-  val xmit : ip:Ip.t -> id:id ->
+  val src: t -> Ip.ipaddr
+  (** Local IP address *)
+
+  val v: src:Ip.ipaddr -> src_port:int -> dst:Ip.ipaddr -> dst_port:int -> t
+  (** [v ~src ~src_port ~dst ~dst_port] is the wire value [v] with the
+      corresponding local and remote IP/TCP parameters. *)
+
+  val xmit: ip:Ip.t -> t ->
     ?rst:bool -> ?syn:bool -> ?fin:bool -> ?psh:bool ->
     rx_ack:Sequence.t option -> seq:Sequence.t -> window:int ->
     options:Options.t list ->
     Cstruct.t -> (unit, error) result Lwt.t
+  (** [xmit] emits a TCP packet over the network. *)
 
 end


### PR DESCRIPTION
- add doc strings
- rename `type id` into `type t`
- rename the `wire` creator function into `v`
- expose `src` to get the local IP