### PR TITLE
Almost but not quite fix Xen linking problem

### DIFF
--- a/META.tcpip.template
+++ b/META.tcpip.template
@@ -1,0 +1,3 @@
+# JBUILDER_GEN
+
+xen_linkopts = "-L@tcpip/xen -ltcpip_xen_stubs"


### PR DESCRIPTION
This patch adds a `xen_link_opts` to the META file for `tcpip` which causes
the `mirage` tool to add

'-L/home/opam/.opam/4.04.2/lib/tcpip/xen' '-ltcpip_xen_stubs'

to any unikernel which uses the `tcpip.xen` package. A separate patch will
be needed to link `tcpip.xen` for Xen targets.

Part of #324

Signed-off-by: David Scott <dave@recoil.org>