### PR TITLE
Add a dependency from tcpip to tcpip.unix

### DIFF
--- a/src/tcpip_checksum/jbuild
+++ b/src/tcpip_checksum/jbuild
@@ -4,7 +4,7 @@
  ((name        tcpip)
   (public_name tcpip)
   (modules (tcpip_checksum))
-  (libraries   (cstruct))
+  (libraries   (cstruct tcpip.unix))
   (wrapped false)))
 
 (library
@@ -29,7 +29,6 @@
 (library
  ((name tcpip_unix)
   (public_name tcpip.unix)
-  (libraries (tcpip))
   (modules (tcpip_unix))
   (c_names (checksum_stubs))
   (wrapped false)))


### PR DESCRIPTION
This is obviously a hack and conceptually wrong but

- it fixes builds with the current mirage tool
- it is the same behaviour as before the recent package restructuring

This works because

- the mirage tool uses `ocamlopt` to link Unix binaries, which will include the "Unix" stubs
- the mirage tool manually links other backends, and ignores the stubs referenced by the OCaml object files

Whenever we have proper cross-compilation for mirage backends we can merge together the `tcpip` `tcpip.unix` and `tcpip.xen` packages.

Related to [mirage/mirage#856]

Signed-off-by: David Scott <dave@recoil.org>