### PR TITLE
Fix build with OCaml 4.06 (and with -safe-string)

### DIFF
--- a/src/ipv4/routing.ml
+++ b/src/ipv4/routing.ml
@@ -8,9 +8,9 @@ let mac_of_multicast ip =
   Bytes.set macb 1 (Char.chr 0x00);
   Bytes.set macb 2 (Char.chr 0x5E);
   Bytes.set macb 3 (Char.chr ((Char.code ipb.[1]) land 0x7F));
-  Bytes.set macb 4 (Bytes.get ipb 2);
-  Bytes.set macb 5 (Bytes.get ipb 3);
-  Macaddr.of_bytes_exn macb
+  Bytes.set macb 4 (String.get ipb 2);
+  Bytes.set macb 5 (String.get ipb 3);
+  Macaddr.of_bytes_exn (Bytes.to_string macb)
 
 type routing_error = [ `Local | `Gateway ]
 

--- a/src/ipv6/ndpv6.ml
+++ b/src/ipv6/ndpv6.ml
@@ -120,7 +120,7 @@ let macaddr_of_cstruct cs =
 
 let interface_addr mac =
   let bmac = Macaddr.to_bytes mac in
-  let c i = Char.code (Bytes.get bmac i) in
+  let c i = Char.code (String.get bmac i) in
   Ipaddr.make
     0 0 0 0
     ((c 0 lxor 2) lsl 8 + c 1)


### PR DESCRIPTION
The names of some `Ipaddr` and `Macaddr` functions are misleading;
when they say "bytes" they mean the encoding within the value, not
the type of the value and not the mutable/immutable-ness.

- `Ipaddr.V4.to_bytes`: this returns a `string` containing a byte
  encoding of the address (not a `bytes` containing a byte encoding
  of the address)
- `Macaddr.of_bytes_exn`: this consumes a `string` containing a
  byte encoding of the MAC address (not a `bytes` containing a
  byte encoding)
- `Macaddr.to_bytes`: this returns a `string` containing a byte
  encoding of the MAC address

Signed-off-by: David Scott <dave@recoil.org>