### PR TITLE
Fix build with OCaml 4.06 (and with -safe-string) again

### DIFF
--- a/test/test_deadlock.ml
+++ b/test/test_deadlock.ml
@@ -111,7 +111,7 @@ let test_digest netif1 netif2 =
                   ]
                 >>= fun () ->
                 send_data data in
-            send_data @@ Cstruct.of_bytes data >>= fun () ->
+            send_data @@ Cstruct.of_string data >>= fun () ->
             Server_log.debug (fun f -> f "wrote data");
             TCPIP.TCPV4.close flow
           end


### PR DESCRIPTION
I think this slipped through because the PR build didn't have 4.06 in
the travis matrix, but master does.

Signed-off-by: David Scott <dave.scott@docker.com>