### PR TITLE
Tcp_socket: avoid raising an exception (`Lwt.fail exn`) when `write` …

### DIFF
--- a/src/stack-unix/tcpv4_socket.mli
+++ b/src/stack-unix/tcpv4_socket.mli
@@ -14,8 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Mirage_protocols_lwt.TCP with type ip = Ipaddr.V4.t option
-                    and type ipaddr = Ipaddr.V4.t
-                    and type ipinput = unit Lwt.t
-                    and type flow = Lwt_unix.file_descr
+include Mirage_protocols_lwt.TCP
+  with type ip = Ipaddr.V4.t option
+   and type ipaddr = Ipaddr.V4.t
+   and type ipinput = unit Lwt.t
+   and type flow = Lwt_unix.file_descr
+   and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
+   and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
+
 val connect : ip -> t Lwt.t

--- a/src/stack-unix/tcpv6_socket.mli
+++ b/src/stack-unix/tcpv6_socket.mli
@@ -15,9 +15,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Mirage_protocols_lwt.TCP with type ip = Ipaddr.V6.t option
-                    and type ipaddr = Ipaddr.V6.t
-                    and type ipinput = unit Lwt.t
-                    and type flow = Lwt_unix.file_descr
+include Mirage_protocols_lwt.TCP
+  with type ip = Ipaddr.V6.t option
+   and type ipaddr = Ipaddr.V6.t
+   and type ipinput = unit Lwt.t
+   and type flow = Lwt_unix.file_descr
+   and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
+   and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
 
 val connect : ip -> t io


### PR DESCRIPTION
…errors,

  instead use the variant ``[ `Exn of exn ]`` in (`Lwt.return (Error (`Exn exn))`)
  as done in `read`
Tcpv4_socket / Tcpv6_socket: expose the custom variants in `type error` and
  `type write_error` in the interface

last time the semantics changed was in 47c8827eb9a488578c4cd41e3fbeb0451ec29bf8 by @djs55 -- I believe since Mirage 3.0 is now out of the door, where we claim to unify error handling by using the result type (i.e. `(data, err) result Lwt.t` instead of `data Lwt.t`), we should adapt the `write` on unix as well.

I don't know whether `` [ `Exn of exn ] `` is a nice type to work with (`Mirage_protocols.Tcp.error` contains ``[ `Timeout | `Refused ]``, whereas the `write_error` adds `` [ `Closed ]`` -- not sure how to best map all the unix socket errors into that sum type (it may need some refinement at a later point).

The purpose of this PR is to unify the MirageOS-as-unikernel-on-a-hypervisor with the Unix backend.  I hate to have to add random noise of `Lwt.catch` in my code after I discover that on Unix I can still get `Lwt.fail` instances.

[EDIT: removed the `close` question, opening another issue for discussing this instead.]