### PR TITLE
Close no err

### DIFF
--- a/src/stack-unix/tcp_socket.ml
+++ b/src/stack-unix/tcp_socket.ml
@@ -56,7 +56,11 @@ let writev_nodelay fd bufs =
   writev fd bufs
 
 let close fd =
-  Lwt_unix.close fd
+  Lwt.catch
+    (fun () -> Lwt_unix.close fd)
+    (function
+      | Unix.Unix_error (Unix.EBADF, _, _) -> Lwt.return_unit
+      | e -> Lwt.fail e)
 
 type listener = {
   process: Lwt_unix.file_descr -> unit Lwt.t;


### PR DESCRIPTION
A subtle issue, which I don't know how to fix properly: when `read` or `write` fail, what is the suggested semantics of the socket?  should it be closed or am I responsible of closing it?  since on Unix, `T.close` can `Lwt.fail` as well (i.e. if the `fd` is already closed), but `Mirage_flow.TCP.close` does only specify `unit io` as return value, I don't know how that should be handled.  For now, I had to `Lwt.catch (fun () -> T.close flow) (fun _ -> Lwt.return_unit)`, so:
- is this the intended behaviour (if so, we should document this in `T.close`)
- should `close` signature be able to return `(unit, err) result io`?
- should `close` just close and ignore potential issues? (as a side note, `close` is one of the trickiest system calls, please read up on https://discuss.ocaml.org/t/system-calls-unix-close-signals-eintr/972)

-- this is an implementation of the last option, please raise your concern if you disagree

NB: AFAIU the direct implementation, there `close` will never `Lwt.fail` (neither able to `Error` out, but it does some Lwt.sequence magic I don't understand)