### PR TITLE
Start preparation for Lwt.async demanding unit Lwt.t

### DIFF
--- a/src/tcp/segment.ml
+++ b/src/tcp/segment.ml
@@ -367,7 +367,9 @@ module Tx (Time:Mirage_time_lwt.S) (Clock:Mirage_clock.MCLOCK) = struct
             let flags=rexmit_seg.flags in
             let options=[] in (* TODO: put the right options *)
             Lwt.async (fun () ->
-                q.xmit ~flags ~wnd ~options ~seq rexmit_seg.data >|= ignore);
+                q.xmit ~flags ~wnd ~options ~seq rexmit_seg.data
+                (* TODO should this return value really be ignored? *)
+                >|= fun (_: ('a,'b) result) -> () );
             Lwt.return_unit
           end else
             Lwt.return_unit

--- a/src/tcp/segment.ml
+++ b/src/tcp/segment.ml
@@ -366,8 +366,8 @@ module Tx (Time:Mirage_time_lwt.S) (Clock:Mirage_clock.MCLOCK) = struct
             let { wnd; _ } = q in
             let flags=rexmit_seg.flags in
             let options=[] in (* TODO: put the right options *)
-            Lwt.async
-              (fun () -> q.xmit ~flags ~wnd ~options ~seq rexmit_seg.data);
+            Lwt.async (fun () ->
+                q.xmit ~flags ~wnd ~options ~seq rexmit_seg.data >|= ignore);
             Lwt.return_unit
           end else
             Lwt.return_unit


### PR DESCRIPTION
Please see https://github.com/ocsigen/lwt/issues/603

This patch ignores the `('a,'e) result` from `q.xmit`
(which was also unhandled previously, so I don't think I have changed the behavior of this code).