### PR TITLE
remove open Result / Result.result types (since June 2017 tcpip requires ocaml 4.03, which provides result in Pervasives)

### DIFF
--- a/src/arpv4/arpv4.ml
+++ b/src/arpv4/arpv4.ml
@@ -16,7 +16,6 @@
  *)
 
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "arpv4" ~doc:"Mirage ARP module"
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -120,11 +119,11 @@ module Make (Ethif : Mirage_protocols_lwt.ETHIF)
     let open Arpv4_packet in
     MProf.Trace.label "arpv4.input";
     match Unmarshal.of_cstruct frame with
-    | Result.Error s ->
+    | Error s ->
       Log.debug (fun f -> f "Failed to parse arpv4 header: %a (buffer: %S)"
                    Unmarshal.pp_error s (Cstruct.to_string frame));
       Lwt.return_unit
-    | Result.Ok arp ->
+    | Ok arp ->
       notify t arp.spa arp.sha; (* cache the sender's mapping. this will get GARPs too *)
       match arp.op with
       | Arpv4_wire.Reply -> Lwt.return_unit

--- a/src/arpv4/arpv4_packet.mli
+++ b/src/arpv4/arpv4_packet.mli
@@ -21,7 +21,7 @@ module Unmarshal : sig
 
   val pp_error : Format.formatter -> error -> unit
 
-  val of_cstruct : Cstruct.t -> (t, error) Result.result
+  val of_cstruct : Cstruct.t -> (t, error) result
 end
 module Marshal : sig
   type error = string
@@ -29,7 +29,7 @@ module Marshal : sig
   (** [into_cstruct t buf] attempts to write an ARP header representing
       [t.op], and the source/destination ip/mac in [t] into [buf] at offset 0.
       [buf] should be at least 24 bytes in size for the call to succeed. *)
-  val into_cstruct : t -> Cstruct.t -> (unit, error) Result.result
+  val into_cstruct : t -> Cstruct.t -> (unit, error) result
 
   (** given a [t], construct and return an ARP header representing
       [t.op], and the source/destination ip/mac in [t].  [make_cstruct] will allocate

--- a/src/ethif/ethif.ml
+++ b/src/ethif/ethif.ml
@@ -15,7 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-open Result
 open Lwt.Infix
 
 let src = Logs.Src.create "ethif" ~doc:"Mirage Ethernet"

--- a/src/ethif/ethif_packet.mli
+++ b/src/ethif/ethif_packet.mli
@@ -10,16 +10,16 @@ val pp : Format.formatter -> t -> unit
 val equal : t -> t -> bool
 
 module Unmarshal : sig
-  val of_cstruct : Cstruct.t -> ((t * Cstruct.t), error) Result.result
+  val of_cstruct : Cstruct.t -> ((t * Cstruct.t), error) result
 end
 module Marshal : sig
   (** [into_cstruct t buf] writes a 14-byte ethernet header representing
       [t.ethertype], [t.src_mac], and [t.dst_mac] to [buf] at offset 0.
-      Return Result.Ok () on success and Result.Error error on failure.
+      Returns [Ok ()] on success and [Error error] on failure.
       Currently, the only possibility for failure
       is a [buf] too small to contain the header; to avoid this, provide a
       buffer of size at least 14. *)
-  val into_cstruct : t -> Cstruct.t -> (unit, error) Result.result
+  val into_cstruct : t -> Cstruct.t -> (unit, error) result
 
   (** given a [t], construct and return an Ethernet header representing
       [t.ethertype], [t.source], and [t.destination].  [make_cstruct] will allocate

--- a/src/icmp/icmpv4.ml
+++ b/src/icmp/icmpv4.ml
@@ -1,5 +1,4 @@
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "icmpv4" ~doc:"Mirage ICMPv4"
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -40,11 +39,11 @@ module Make(IP : Mirage_protocols_lwt.IPV4) = struct
     let should_reply t dst = List.mem dst @@ IP.get_ip t.ip in
     MProf.Trace.label "icmp_input";
     match Unmarshal.of_cstruct buf with
-    | Result.Error s ->
+    | Error s ->
       Log.info (fun f ->
           f "ICMP: error parsing message from %a: %s" Ipaddr.V4.pp_hum src s);
       Lwt.return_unit
-    | Result.Ok (message, payload) ->
+    | Ok (message, payload) ->
       let open Icmpv4_wire in
       match message.ty, message.subheader with
       | Echo_reply, _ ->

--- a/src/icmp/icmpv4_packet.ml
+++ b/src/icmp/icmpv4_packet.ml
@@ -61,19 +61,19 @@ module Unmarshal = struct
     let open Rresult in
     let check_len () =
       if Cstruct.len buf < sizeof_icmpv4 then
-        Result.Error "packet too short for ICMPv4 header"
-      else Result.Ok () in
+        Error "packet too short for ICMPv4 header"
+      else Ok () in
     let check_ty () =
       match int_to_ty (get_icmpv4_ty buf) with
-      | None -> Result.Error "unrecognized ICMPv4 type"
-      | Some ty -> Result.Ok ty
+      | None -> Error "unrecognized ICMPv4 type"
+      | Some ty -> Ok ty
     in
     (* TODO: check checksum as well, and return an error if it's invalid *)
     check_len () >>= check_ty >>= fun ty ->
     let code = get_icmpv4_code buf in
     let subheader = subheader_of_cstruct ty (Cstruct.shift buf 4) in
     let payload = Cstruct.shift buf sizeof_icmpv4 in
-    Result.Ok ({ code; ty; subheader}, payload)
+    Ok ({ code; ty; subheader}, payload)
 end
 
 module Marshal = struct
@@ -99,14 +99,14 @@ module Marshal = struct
 
   let check_len buf =
     if Cstruct.len buf < Icmpv4_wire.sizeof_icmpv4 then
-      Result.Error "Not enough space for ICMP header"
-    else Result.Ok ()
+      Error "Not enough space for ICMP header"
+    else Ok ()
 
   let into_cstruct t buf ~payload =
     let open Rresult in
     check_len buf >>= fun () ->
     unsafe_fill t buf ~payload;
-    Result.Ok ()
+    Ok ()
 
   let make_cstruct t ~payload =
     let buf = Cstruct.create Icmpv4_wire.sizeof_icmpv4 in

--- a/src/icmp/icmpv4_packet.mli
+++ b/src/icmp/icmpv4_packet.mli
@@ -19,7 +19,7 @@ module Unmarshal : sig
 
   val subheader_of_cstruct : Icmpv4_wire.ty -> Cstruct.t -> subheader
 
-  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) Result.result
+  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) result
 end
 module Marshal : sig
   type error = string
@@ -28,7 +28,7 @@ module Marshal : sig
       writes it into [buf] at offset 0. [payload] is used to calculate the ICMPv4 header
       checksum, but is not included in the generated buffer. [into_cstruct] may
       fail if the buffer is of insufficient size. *)
-  val into_cstruct : t -> Cstruct.t -> payload:Cstruct.t -> (unit, error) Result.result
+  val into_cstruct : t -> Cstruct.t -> payload:Cstruct.t -> (unit, error) result
 
   (** [make_cstruct t ~payload] allocates, fills, and returns a Cstruct.t with the header
       information from [t].  The payload is used to calculate the ICMPv4 header

--- a/src/ipv4/ipv4_packet.mli
+++ b/src/ipv4/ipv4_packet.mli
@@ -19,7 +19,7 @@ module Unmarshal : sig
 
   val int_to_protocol : int -> protocol option
 
-  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) Result.result
+  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) result
 
   val verify_transport_checksum : proto:([`TCP | `UDP]) -> ipv4_header:t ->
       transport_packet:Cstruct.t -> bool
@@ -37,7 +37,7 @@ module Marshal : sig
 (** [into_cstruct ~payload_len t buf] attempts to write a header representing [t] (including
     [t.options]) into [buf] at offset 0.
     If there is insufficient space to represent [t], an error will be returned. *)
-  val into_cstruct : payload_len:int -> t -> Cstruct.t -> (unit, error) Result.result
+  val into_cstruct : payload_len:int -> t -> Cstruct.t -> (unit, error) result
 
   (** [make_cstruct ~payload_len t] allocates, fills, and returns a buffer
       repesenting the IPV4 header corresponding to [t].

--- a/src/ipv4/routing.ml
+++ b/src/ipv4/routing.ml
@@ -1,5 +1,3 @@
-open Result
-
 (* RFC 1112: 01-00-5E-00-00-00 ORed with lower 23 bits of the ip address *)
 let mac_of_multicast ip =
   let ipb = Ipaddr.V4.to_bytes ip in

--- a/src/ipv4/static_ipv4.ml
+++ b/src/ipv4/static_ipv4.ml
@@ -15,7 +15,6 @@
  *)
 
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "ipv4" ~doc:"Mirage IPv4"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -20,7 +20,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module I = Ipaddr
 
 open Lwt.Infix
-open Result
 
 module Make (E : Mirage_protocols_lwt.ETHIF)
             (R : Mirage_random.C)

--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -15,7 +15,6 @@
  *)
 
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "tcpip-stack-direct" ~doc:"Pure OCaml TCP/IP stack"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/stack-unix/icmpv4_socket.ml
+++ b/src/stack-unix/icmpv4_socket.ml
@@ -67,11 +67,11 @@ let write _t ~dst buf =
 let input t ~src ~dst:_ buf =
   (* some default logic -- respond to echo requests with echo replies *)
   match Icmpv4_packet.Unmarshal.of_cstruct buf with
-  | Result.Error s ->
+  | Error s ->
     let s = "Error decomposing an ICMP packet: " ^ s in
     Logs.debug (fun f -> f "%s" s);
     Lwt.return_unit
-  | Result.Ok (icmp, payload) ->
+  | Ok (icmp, payload) ->
     let open Icmpv4_packet in
     match icmp.ty, icmp.subheader with
     | Icmpv4_wire.Echo_request, Id_and_seq (id, seq) ->

--- a/src/stack-unix/tcp_socket.ml
+++ b/src/stack-unix/tcp_socket.ml
@@ -1,5 +1,4 @@
 open Lwt
-open Result
 
 type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
 type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]

--- a/src/stack-unix/tcpv4_socket.ml
+++ b/src/stack-unix/tcpv4_socket.ml
@@ -15,7 +15,6 @@
  *)
 
 open Lwt
-open Result
 
 type buffer = Cstruct.t
 type ipaddr = Ipaddr.V4.t

--- a/src/stack-unix/tcpv6_socket.ml
+++ b/src/stack-unix/tcpv6_socket.ml
@@ -16,7 +16,6 @@
  *)
 
 open Lwt
-open Result
 
 type buffer = Cstruct.t
 type ipaddr = Ipaddr.V6.t

--- a/src/stack-unix/udpv4_socket.ml
+++ b/src/stack-unix/udpv4_socket.ml
@@ -15,7 +15,6 @@
  *)
 
 open Lwt
-open Result
 
 type buffer = Cstruct.t
 type ipaddr = Ipaddr.V4.t

--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -16,7 +16,6 @@
  *)
 
 open Lwt.Infix
-open !Result
 
 let src = Logs.Src.create "pcb" ~doc:"Mirage TCP PCB module"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/tcp/options.ml
+++ b/src/tcp/options.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 (* TCP options parsing *)
 
 type t =

--- a/src/tcp/options.mli
+++ b/src/tcp/options.mli
@@ -28,6 +28,6 @@ type t =
 val equal: t -> t -> bool
 val lenv: t list -> int (* how many bytes are required to marshal this list *)
 val marshal: Cstruct.t -> t list -> int
-val unmarshal : Cstruct.t -> (t list, string) Result.result
+val unmarshal : Cstruct.t -> (t list, string) result
 val pp : Format.formatter -> t -> unit
 val pps : Format.formatter -> t list -> unit

--- a/src/tcp/segment.ml
+++ b/src/tcp/segment.ml
@@ -15,7 +15,6 @@
  *)
 
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "segment" ~doc:"Mirage TCP Segment module"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/tcp/segment.mli
+++ b/src/tcp/segment.mli
@@ -24,8 +24,6 @@
     the Rtx queue to ack messages or close channels.
 *)
 
-open Result
-
 module Rx (T:Mirage_time_lwt.S) : sig
 
   type segment = { header: Tcp_packet.t; payload: Cstruct.t }

--- a/src/tcp/tcp_packet.ml
+++ b/src/tcp/tcp_packet.ml
@@ -38,12 +38,12 @@ module Unmarshal = struct
     let open Tcp_wire in
     let check_len pkt =
       if Cstruct.len pkt < sizeof_tcp then
-        Result.Error "packet too short to contain a TCP packet of any size"
+        Error "packet too short to contain a TCP packet of any size"
       else
         Ok (Tcp_wire.get_data_offset pkt)
     in
     let long_enough data_offset = if Cstruct.len pkt < data_offset then
-        Result.Error "packet too short to contain a TCP packet of the size claimed"
+        Error "packet too short to contain a TCP packet of the size claimed"
       else
         Ok ()
     in
@@ -51,7 +51,7 @@ module Unmarshal = struct
       if data_offset > 20 then
         Options.unmarshal (Cstruct.sub pkt sizeof_tcp (data_offset - sizeof_tcp))
       else if data_offset < 20 then
-        Result.Error "data offset was unreasonably short; TCP header can't be valid"
+        Error "data offset was unreasonably short; TCP header can't be valid"
       else (Ok [])
     in
     check_len pkt >>= fun data_offset ->
@@ -69,8 +69,8 @@ module Unmarshal = struct
     let src_port = get_tcp_src_port pkt in
     let dst_port = get_tcp_dst_port pkt in
     let data = Cstruct.shift pkt data_offset in
-    Result.Ok ({ urg; ack; psh; rst; syn; fin; window; options;
-                sequence; ack_number; src_port; dst_port }, data)
+    Ok ({ urg; ack; psh; rst; syn; fin; window; options;
+          sequence; ack_number; src_port; dst_port }, data)
 end
 module Marshal = struct
   open Rresult

--- a/src/tcp/tcp_packet.mli
+++ b/src/tcp/tcp_packet.mli
@@ -19,7 +19,7 @@ val equal : t -> t -> bool
 module Unmarshal : sig
   type error = string
 
-  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) Result.result
+  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) result
 end
 
 module Marshal : sig
@@ -37,7 +37,7 @@ module Marshal : sig
     pseudoheader:Cstruct.t ->
     payload:Cstruct.t      ->
     t -> Cstruct.t ->
-    (int, error) Result.result
+    (int, error) result
 
   (** [make_cstruct ~pseudoheader ~payload t] allocates, fills, and and returns a buffer
       representing the TCP header corresponding to [t].  If [t.options] is

--- a/src/tcp/wire.ml
+++ b/src/tcp/wire.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "Wire" ~doc:"Mirage TCP Wire module"
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -67,10 +66,10 @@ module Make (Ip:Mirage_protocols_lwt.IP) = struct
     let pseudoheader = Ip.pseudoheader ip ~dst ~proto:`TCP
       (Tcp_wire.sizeof_tcp + Options.lenv options + Cstruct.len payload) in
     match Tcp_packet.Marshal.into_cstruct header tcp_buf ~pseudoheader ~payload with
-    | Result.Error s ->
+    | Error s ->
       Log.warn (fun l -> l "Error writing TCP packet header: %s" s);
       Lwt.fail (Failure ("Tcp_packet.Marshal.into_cstruct: " ^ s))
-    | Result.Ok len ->
+    | Ok len ->
       let frame = Cstruct.set_len frame (header_len + len) in
       MProf.Counter.increase count_tcp_to_ip
         (Cstruct.len payload + if syn then 1 else 0);

--- a/src/tcp/wire.mli
+++ b/src/tcp/wire.mli
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 module Make (Ip:Mirage_protocols_lwt.IP) : sig
 
   type error = Mirage_protocols.Ip.error

--- a/src/udp/udp.ml
+++ b/src/udp/udp.ml
@@ -15,7 +15,6 @@
  *)
 
 open Lwt.Infix
-open Result
 
 let src = Logs.Src.create "udp" ~doc:"Mirage UDP"
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/udp/udp_packet.mli
+++ b/src/udp/udp_packet.mli
@@ -13,7 +13,7 @@ module Unmarshal : sig
 (** [of_cstruct buf] attempts to interpret [buf] as a UDP header.  If
     successful, it returns [Ok (header, payload)], although [payload] may be an
     empty Cstruct.t . *)
-  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) Result.result
+  val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) result
 end
 module Marshal : sig
 
@@ -28,7 +28,7 @@ module Marshal : sig
     pseudoheader:Cstruct.t  ->
     payload:Cstruct.t       ->
     t -> Cstruct.t ->
-    (unit, error) Result.result
+    (unit, error) result
 
   (** [make_cstruct ~pseudoheader ~payload t] allocates, fills, and and returns a buffer
       representing the UDP header corresponding to [t].  [make_cstruct] will

--- a/test/test_arp.ml
+++ b/test/test_arp.ml
@@ -1,5 +1,4 @@
 open Lwt.Infix
-open Result
 
 let time_reduction_factor = 60
 

--- a/test/test_icmpv4.ml
+++ b/test/test_icmpv4.ml
@@ -1,5 +1,4 @@
 open Common
-open Result
 
 module Time = Vnetif_common.Time
 module B = Basic_backend.Make

--- a/test/test_ipv4.ml
+++ b/test/test_ipv4.ml
@@ -6,7 +6,7 @@ let test_unmarshal_with_options () =
                             "\x42\x49\xc0\xa8\x01\x08\xe0\x00\x00\x16\x94\x04\x00\x00\x22" ^
                             "\x00\xfa\x02\x00\x00\x00\x01\x03\x00\x00\x00\xe0\x00\x00\xfb") 0 datagram 0 40;
   match Ipv4_packet.Unmarshal.of_cstruct datagram with
-  | Result.Ok ({Ipv4_packet.options ; _}, payload) ->
+  | Ok ({Ipv4_packet.options ; _}, payload) ->
       Alcotest.(check int) "options" (Cstruct.len options) 4;
       Alcotest.(check int) "payload" (Cstruct.len payload) 16;
       Lwt.return_unit
@@ -20,7 +20,7 @@ let test_unmarshal_without_options () =
                             "\x9c\xca\xc0\xa8\x01\x08\x00\x50\xca\xa6\x6f\x19\xf4\x76" ^
                             "\x00\x00\x00\x00\x50\x04\x00\x00\xec\x27\x00\x00") 0 datagram 0 40;
   match Ipv4_packet.Unmarshal.of_cstruct datagram with
-  | Result.Ok ({Ipv4_packet.options ; _}, payload) ->
+  | Ok ({Ipv4_packet.options ; _}, payload) ->
       Alcotest.(check int) "options" (Cstruct.len options) 0;
       Alcotest.(check int) "payload" (Cstruct.len payload) 20;
       Lwt.return_unit

--- a/test/test_rfc5961.ml
+++ b/test/test_rfc5961.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 open Common
-open Result
 open Lwt.Infix
 
 (*

--- a/test/test_tcp_options.ml
+++ b/test/test_tcp_options.ml
@@ -4,11 +4,11 @@ let check = Alcotest.(check @@ result (list options) string)
 
 let errors ?(check_msg = false) exp = function
   | Ok opt ->
-    Fmt.kstrf Alcotest.fail "Result.Ok %a when Result.error %s expected"
+    Fmt.kstrf Alcotest.fail "Ok %a when Error %s expected"
       Tcp.Options.pps opt exp
   | Error p -> if check_msg then
       Alcotest.(check string)
-        "Result.Error didn't give the expected error message" exp p
+        "Error didn't give the expected error message" exp p
     else ()
 
 let test_unmarshal_bad_mss () =

--- a/test/test_udp.ml
+++ b/test/test_udp.ml
@@ -1,5 +1,4 @@
 open Common
-open Result
 
 module Time = Vnetif_common.Time
 module B = Basic_backend.Make

--- a/test/vnetif_backends.ml
+++ b/test/vnetif_backends.ml
@@ -15,7 +15,6 @@
  *)
 
 let (>>=) = Lwt.(>>=)
-open Result
 
 module type Backend = sig
   include Vnetif.BACKEND


### PR DESCRIPTION
and tcpip opam file does not specify the `result` package as dependency...  this should be safe! :)

in addition, upcoming OCaml 4.08.0 will contain a more extensive `Result` module, which may have unwanted effects (shadowing of names) if we open it globally ;)