### PR TITLE
Native implementation of checksum for jsoo

### DIFF
--- a/src/tcpip_checksum/tcpip_checksum.ml
+++ b/src/tcpip_checksum/tcpip_checksum.ml
@@ -15,6 +15,59 @@
  *)
 
 (** One's complement checksum, RFC1071 *)
-external ones_complement: Cstruct.t -> int = "caml_tcpip_ones_complement_checksum"
+(* external ones_complement: Cstruct.t -> int = "caml_tcpip_ones_complement_checksum" *)
 
-external ones_complement_list: Cstruct.t list -> int = "caml_tcpip_ones_complement_checksum_list"
+(* external ones_complement_list: Cstruct.t list -> int = "caml_tcpip_ones_complement_checksum_list" *)
+
+let rec finalise_checksum cs =
+  assert (cs >= 0);
+  if cs < 0x10000 then
+    lnot cs land 0xffff
+  else
+    finalise_checksum ((cs land 0xffff) + (cs lsr 16))
+
+let ones_complement (buffer: Cstruct.t) =
+  let len = Cstruct.len buffer in
+  let rec do_checksum checksum offset =
+    if offset + 1 < len then (
+      let checksum = checksum + Cstruct.BE.get_uint16 buffer offset in
+      do_checksum checksum (offset + 2)
+    ) else if offset + 1 = len then (
+      let checksum = checksum + (Cstruct.get_uint8 buffer offset lsl 8) in
+      finalise_checksum checksum
+    ) else
+      finalise_checksum checksum
+  in
+  do_checksum 0 0
+
+let ones_complement_list buffers =
+  let rec do_checksum checksum offset len buffer buffers =
+    if offset + 1 < len then (
+      let checksum = checksum + Cstruct.BE.get_uint16 buffer offset in
+      do_checksum checksum (offset + 2) len buffer buffers
+    ) else (
+      let extra_single_byte = offset + 1 = len in
+      match buffers with
+      | [] ->
+        let checksum =
+          checksum +
+          if extra_single_byte then Cstruct.get_uint8 buffer offset lsl 8 else 0
+        in
+        finalise_checksum checksum
+      | next_buffer :: buffers ->
+        let checksum =
+          checksum +
+          if extra_single_byte
+            then Cstruct.get_uint8 next_buffer 0 + (Cstruct.get_uint8 buffer offset lsl 8)
+            else 0
+        in
+        let offset = if extra_single_byte then 1 else 0 in
+        let len = Cstruct.len next_buffer in
+        do_checksum checksum offset len next_buffer buffers
+    )
+  in
+  match buffers with
+  | buffer :: buffers ->
+    let len = Cstruct.len buffer in
+    do_checksum 0 0 len buffer buffers
+  | [] -> finalise_checksum 0


### PR DESCRIPTION
Implement `ones_complement` and `ones_complement_list` in OCaml for support of `js_of_ocaml`.

As per https://github.com/mirage/mirage-tcpip/issues/378#issuecomment-446861272, leaves the native versions disabled for a later fixup.