### PR TITLE
don't suppress deprecation warnings (3)

### DIFF
--- a/src/tcp/segment.ml
+++ b/src/tcp/segment.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-[@@@ocaml.warning "-3"]
-
 open Lwt.Infix
 
 let src = Logs.Src.create "segment" ~doc:"Mirage TCP Segment module"

--- a/src/tcp/user_buffer.ml
+++ b/src/tcp/user_buffer.ml
@@ -15,8 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-[@@@ocaml.warning "-3"]
-
 open Lwt.Infix
 
 let lwt_sequence_add_l s seq =


### PR DESCRIPTION
as noticed in https://github.com/mirage/mirage-net-xen/pull/79#discussion_r245473869 - I'm actually in favour of not suppressing warnings to remind ourselves that we need to work on this... Lwt_sequence getting deprecated as tracked in https://github.com/mirage/mirage/issues/889