### PR TITLE
Rename ethif to ethernet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script: bash -ex .travis-ci.sh
 sudo: required
 env:
   global:
-  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
   matrix:
   - OCAML_VERSION=4.04 PACKAGE=tcpip MIRAGE_MODE=unix FLAGS="--net=socket"
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.04 PACKAGE=tcpip MIRAGE_MODE=xen

--- a/examples/unikernel/services.ml
+++ b/examples/unikernel/services.ml
@@ -13,10 +13,8 @@ module Main (S: Mirage_types_lwt.STACKV4) = struct
       "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ "
     in
     let make_chars how_many start_at =
-      let buf = Io_page.(to_cstruct (get 1)) in
       let output = (String.sub (charpool ^ charpool) start_at how_many) ^ "\n" in
-      Cstruct.blit_from_string output 0 buf 0 (String.length output);
-      Cstruct.set_len buf (String.length output)
+      Cstruct.of_string output
     in
 
     S.TCPV4.write flow (make_chars how_many start_at) >>= function

--- a/src/icmp/icmpv4.ml
+++ b/src/icmp/icmpv4.ml
@@ -24,10 +24,8 @@ module Make(IP : Mirage_protocols_lwt.IPV4) = struct
   let disconnect _ = Lwt.return_unit
 
   let writev t ~dst bufs =
-    let frame, header_len = IP.allocate_frame t.ip ~dst ~proto:`ICMP in
-    let frame = Cstruct.set_len frame header_len in
-    IP.writev t.ip frame bufs >|= function
-    | Ok () as o -> o
+    IP.write t.ip dst `ICMP (fun _ -> 0) bufs >|= function
+    | Ok () -> Ok ()
     | Error e ->
       Log.warn (fun f -> f "Error sending IP packet: %a" IP.pp_error e);
       Error (`Ip e)

--- a/src/ipv4/dune
+++ b/src/ipv4/dune
@@ -2,7 +2,7 @@
  (name tcpip_ipv4)
  (public_name tcpip.ipv4)
  (libraries logs mirage-protocols-lwt ipaddr cstruct rresult tcpip
-   ethernet tcpip.udp mirage-random mirage-clock randomconv lru)
+   tcpip.udp mirage-random mirage-clock randomconv lru)
  (preprocess
   (pps ppx_cstruct))
  (wrapped false))

--- a/src/ipv4/dune
+++ b/src/ipv4/dune
@@ -1,7 +1,7 @@
 (library
  (name tcpip_ipv4)
  (public_name tcpip.ipv4)
- (libraries logs io-page mirage-protocols-lwt ipaddr cstruct rresult tcpip
+ (libraries logs mirage-protocols-lwt ipaddr cstruct rresult tcpip
    ethernet tcpip.udp mirage-random mirage-clock randomconv lru)
  (preprocess
   (pps ppx_cstruct))

--- a/src/ipv4/ipv4_common.ml
+++ b/src/ipv4/ipv4_common.ml
@@ -1,41 +1,6 @@
-let adjust_output_header ~rng ~dmac ~tlen frame =
+let set_checksum buf =
   let open Ipv4_wire in
-  Ethernet_wire.set_ethernet_dst dmac 0 frame;
-  let buf = Cstruct.sub frame Ethernet_wire.sizeof_ethernet sizeof_ipv4 in
   (* Set the mutable values in the ipv4 header *)
-  set_ipv4_len buf tlen;
-  set_ipv4_id buf (Randomconv.int16 rng);
   set_ipv4_csum buf 0;
   let checksum = Tcpip_checksum.ones_complement buf in
   set_ipv4_csum buf checksum
-
-let allocate_frame ~src ~source ~(dst:Ipaddr.V4.t) ~(proto : [`ICMP | `TCP | `UDP]) : (Cstruct.t * int) =
-  let open Ipv4_wire in
-  let ethernet_frame = Io_page.to_cstruct (Io_page.get 1) in
-  let len = Ethernet_wire.sizeof_ethernet + sizeof_ipv4 in
-  let eth_header = Ethernet_packet.({ethertype = Ethernet_wire.IPv4;
-                                     source;
-                                     destination = Macaddr.broadcast}) in
-  match Ethernet_packet.Marshal.into_cstruct eth_header ethernet_frame with
-  | Error _s ->
-    raise (Invalid_argument "writing ethif header to ipv4.allocate_frame failed")
-  | Ok () ->
-    let buf = Cstruct.shift ethernet_frame Ethernet_wire.sizeof_ethernet in
-    (* TODO: why 38 for TTL? *)
-    let ipv4_header = Ipv4_packet.({options = Cstruct.create 0;
-                                    src; dst; ttl = 38;
-                                    off = 0 ; id = 0x0000 ;
-                                    proto = Ipv4_packet.Marshal.protocol_to_int proto; }) in
-    (* set the payload_len to 0, since we don't know what it'll be yet *)
-    (* the caller needs to then use [writev] or [write] to output the buffer;
-       otherwise length, id, and checksum won't be set properly *)
-    match Ipv4_packet.Marshal.into_cstruct ~payload_len:0 ipv4_header buf with
-    | Error _s ->
-      raise (Invalid_argument "writing ipv4 header to ipv4.allocate_frame failed")
-    | Ok () ->
-      (ethernet_frame, len)
-
-let checksum frame bufs =
-  let packet = Cstruct.shift frame Ethernet_wire.sizeof_ethernet in
-  Ipv4_wire.set_ipv4_csum packet 0;
-  Tcpip_checksum.ones_complement_list (packet :: bufs)

--- a/src/ipv4/ipv4_packet.ml
+++ b/src/ipv4/ipv4_packet.ml
@@ -55,6 +55,8 @@ module Marshal = struct
     in
     let options_len = nearest_4 @@ Cstruct.len t.options in
     set_ipv4_hlen_version buf ((4 lsl 4) + 5 + (options_len / 4));
+    set_ipv4_id buf t.id;
+    set_ipv4_off buf t.off;
     set_ipv4_ttl buf t.ttl;
     set_ipv4_proto buf t.proto;
     set_ipv4_src buf (Ipaddr.V4.to_int32 t.src);

--- a/src/ipv4/ipv4_packet.mli
+++ b/src/ipv4/ipv4_packet.mli
@@ -32,7 +32,7 @@ module Marshal : sig
 
   val protocol_to_int : protocol -> Cstruct.uint16
 
-  val pseudoheader : src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> proto:([< `TCP | `UDP])
+  val pseudoheader : src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> proto:protocol
     -> int -> Cstruct.t
     (** [pseudoheader src dst proto len] constructs a pseudoheader, suitable for inclusion in transport-layer checksum calculations, including the information supplied.  [len] should be the total length of the transport-layer header and payload.  *)
 

--- a/src/ipv4/static_ipv4.mli
+++ b/src/ipv4/static_ipv4.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (R: Mirage_random.C) (C: Mirage_clock.MCLOCK) (E: Mirage_protocols_lwt.ETHIF) (A: Mirage_protocols_lwt.ARP) : sig
+module Make (R: Mirage_random.C) (C: Mirage_clock.MCLOCK) (E: Mirage_protocols_lwt.ETHERNET) (A: Mirage_protocols_lwt.ARP) : sig
   include Mirage_protocols_lwt.IPV4
   val connect :
     ?ip:Ipaddr.V4.t ->

--- a/src/ipv6/dune
+++ b/src/ipv6/dune
@@ -1,7 +1,7 @@
 (library
  (name tcpip_ipv6)
  (public_name tcpip.ipv6)
- (libraries logs io-page mirage-protocols-lwt mirage-time-lwt
+ (libraries logs mirage-protocols-lwt mirage-time-lwt
    mirage-clock-lwt duration ipaddr cstruct rresult mirage-random tcpip
    randomconv ethernet)
  (preprocess

--- a/src/ipv6/dune
+++ b/src/ipv6/dune
@@ -3,7 +3,7 @@
  (public_name tcpip.ipv6)
  (libraries logs mirage-protocols-lwt mirage-time-lwt
    mirage-clock-lwt duration ipaddr cstruct rresult mirage-random tcpip
-   randomconv ethernet)
+   randomconv)
  (preprocess
   (pps ppx_cstruct))
  (wrapped false))

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -41,34 +41,40 @@ module Make (E : Mirage_protocols_lwt.ETHIF)
     | #Mirage_protocols.Ip.error as e -> Mirage_protocols.Ip.pp_error ppf e
     | `Ethif e -> E.pp_error ppf e
 
+  let output t (dst, size, fill) =
+    E.write t.ethif dst `IPv6 ~size fill
+
+  let output_ign t a = output t a >|= fun _ -> ()
+
   let start_ticking t =
     let rec loop () =
       let now = C.elapsed_ns t.clock in
-      let ctx, bufs = Ndpv6.tick ~now t.ctx in
+      let ctx, outs = Ndpv6.tick ~now t.ctx in
       t.ctx <- ctx;
-      Lwt_list.iter_s (fun buf ->
-          E.writev t.ethif buf >>= fun _ ->
-          Lwt.return_unit
-        ) bufs (* MCP: replace with propagation *) >>= fun () ->
+      Lwt_list.iter_s (output_ign t) outs (* MCP: replace with propagation *) >>= fun () ->
       T.sleep_ns (Duration.of_sec 1) >>= loop
     in
     loop ()
 
-  let allocate_frame t ~dst ~proto =
-    Ndpv6.allocate_frame t.ctx dst proto
+  let mtu t = E.mtu t.ethif - Ipv6_wire.sizeof_ipv6
 
-  let mtu t =
-    E.mtu t.ethif - Ipv6_wire.sizeof_ipv6
-
-  let writev t frame bufs =
+  let write t ?fragment:_ ?ttl:_ ?src:_ dst proto ?(size = 0) headerf bufs =
     let now = C.elapsed_ns t.clock in
-    let dst =
-      Ndpv6.ipaddr_of_cstruct
-        (Ipv6_wire.get_ipv6_dst (Cstruct.shift frame Ethernet_wire.sizeof_ethernet))
+    (* TODO fragmentation! *)
+    let payload = Cstruct.concat bufs in
+    let size' = size + Cstruct.len payload in
+    let fillf _ip6hdr buf =
+      let h_len = headerf buf in
+      if h_len > size then begin
+        Log.err (fun m -> m "provided headerf exceeds size") ;
+        invalid_arg "headerf exceeds size"
+      end ;
+      Cstruct.blit payload 0 buf h_len (Cstruct.len payload);
+      h_len + Cstruct.len payload
     in
-    let ctx, bufs = Ndpv6.send ~now t.ctx dst frame bufs in
+    let ctx, outs = Ndpv6.send ~now t.ctx dst proto size' fillf in
     t.ctx <- ctx;
-    let fail_any progress buf =
+    let fail_any progress data =
       let squeal = function
       | Ok () as ok -> Lwt.return ok
       | Error e ->
@@ -76,46 +82,35 @@ module Make (E : Mirage_protocols_lwt.ETHIF)
         Lwt.return @@ Error (`Ethif e)
       in
       match progress with
-      | Ok () -> E.writev t.ethif buf >>= squeal
+      | Ok () -> output t data >>= squeal
       | Error e -> Lwt.return @@ Error e
     in
     (* MCP - it's not totally clear to me that this the right behavior
        for writev. *)
-    Lwt_list.fold_left_s fail_any (Ok ()) bufs
-
-  let write t frame buf =
-    writev t frame [buf]
+    Lwt_list.fold_left_s fail_any (Ok ()) outs
 
   let input t ~tcp ~udp ~default buf =
     let now = C.elapsed_ns t.clock in
-    let _, bufs, actions = Ndpv6.handle ~now ~random:R.generate t.ctx buf in
+    let _, outs, actions = Ndpv6.handle ~now ~random:R.generate t.ctx buf in
     Lwt_list.iter_s (function
         | `Tcp (src, dst, buf) -> tcp ~src ~dst buf
         | `Udp (src, dst, buf) -> udp ~src ~dst buf
         | `Default (proto, src, dst, buf) -> default ~proto ~src ~dst buf
       ) actions >>= fun () ->
     (* MCP: replace below w/proper error propagation *)
-    Lwt_list.iter_s (fun buf ->
-        E.writev t.ethif buf >>= fun _ ->
-        Lwt.return_unit
-      ) bufs
+    Lwt_list.iter_s (output_ign t) outs
 
   let disconnect _ = (* TODO *)
     Lwt.return_unit
-
-  let checksum = Ndpv6.checksum
 
   let src t ~dst = Ndpv6.select_source t.ctx dst
 
   let set_ip t ip =
     let now = C.elapsed_ns t.clock in
-    let ctx, bufs = Ndpv6.add_ip ~now t.ctx ip in
+    let ctx, outs = Ndpv6.add_ip ~now t.ctx ip in
     t.ctx <- ctx;
     (* MCP: replace the below *)
-    Lwt_list.iter_s (fun buf ->
-        E.writev t.ethif buf >>= fun _ ->
-        Lwt.return_unit
-      ) bufs
+    Lwt_list.iter_s (output_ign t) outs
 
   let get_ip t =
     Ndpv6.get_ip t.ctx
@@ -132,16 +127,16 @@ module Make (E : Mirage_protocols_lwt.ETHIF)
     t.ctx <- ctx;
     Lwt.return_unit
 
-  let pseudoheader t ~dst ~proto len =
+  let pseudoheader t ?src:source dst proto len =
     let ph = Cstruct.create (16 + 16 + 8) in
-    let src = src t ~dst in
+    let src = match source with None -> src t ~dst | Some x -> x in
     Ndpv6.ipaddr_to_cstruct_raw src ph 0;
     Ndpv6.ipaddr_to_cstruct_raw dst ph 16;
     Cstruct.BE.set_uint32 ph 32 (Int32.of_int len);
     Cstruct.set_uint8 ph 36 0;
     Cstruct.set_uint8 ph 37 0;
     Cstruct.set_uint8 ph 38 0;
-    Cstruct.set_uint8 ph 39 (match proto with | `UDP -> 17 | `TCP -> 6);
+    Cstruct.set_uint8 ph 39 (Ipv6_wire.protocol_to_int proto);
     ph
 
   type uipaddr = I.t
@@ -155,13 +150,10 @@ module Make (E : Mirage_protocols_lwt.ETHIF)
   let connect ?ip ?netmask ?gateways ethif clock =
     Log.info (fun f -> f "IP6: Starting");
     let now = C.elapsed_ns clock in
-    let ctx, bufs = Ndpv6.local ~now ~random:R.generate (E.mac ethif) in
+    let ctx, outs = Ndpv6.local ~now ~random:R.generate (E.mac ethif) in
     let t = {ctx; clock; ethif} in
     (* MCP: replace this error swallowing with proper propagation *)
-    Lwt_list.iter_s (fun buf ->
-        E.writev t.ethif buf >>= fun _ ->
-        Lwt.return_unit
-      ) bufs >>= fun () ->
+    Lwt_list.iter_s (output_ign t) outs >>= fun () ->
     (ip, Lwt_list.iter_s (set_ip t)) >>=? fun () ->
     (netmask, Lwt_list.iter_s (set_ip_netmask t)) >>=? fun () ->
     (gateways, set_ip_gateways t) >>=? fun () ->

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -21,7 +21,7 @@ module I = Ipaddr
 
 open Lwt.Infix
 
-module Make (E : Mirage_protocols_lwt.ETHIF)
+module Make (E : Mirage_protocols_lwt.ETHERNET)
             (R : Mirage_random.C)
             (T : Mirage_time_lwt.S)
             (C : Mirage_clock_lwt.MCLOCK) = struct

--- a/src/ipv6/ipv6.mli
+++ b/src/ipv6/ipv6.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (E : Mirage_protocols_lwt.ETHIF)
+module Make (E : Mirage_protocols_lwt.ETHERNET)
             (R : Mirage_random.C)
             (T : Mirage_time_lwt.S)
             (Clock : Mirage_clock_lwt.MCLOCK) : sig

--- a/src/stack-direct/dune
+++ b/src/stack-direct/dune
@@ -2,4 +2,4 @@
  (name tcpip_stack_direct)
  (public_name tcpip.stack-direct)
  (libraries logs ipaddr lwt result fmt mirage-time-lwt mirage-random
-   mirage-protocols-lwt mirage-stack-lwt mirage-net-lwt))
+   mirage-protocols-lwt mirage-stack-lwt mirage-net-lwt ethernet))

--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -106,7 +106,7 @@ module Make
         ~ipv6:(fun _ -> Lwt.return_unit)
         t.ethif
     in
-    Netif.listen t.netif ethif_listener
+    Netif.listen t.netif ~header_size:Ethernet_wire.sizeof_ethernet ethif_listener
     >>= function
     | Error e ->
       Log.warn (fun p -> p "%a" Netif.pp_error e) ;

--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -27,15 +27,15 @@ module type TCPV4_DIRECT = Mirage_protocols_lwt.TCPV4
   with type ipinput = direct_ipv4_input
 
 module Make
-    (Time    : Mirage_time.S)
-    (Random  : Mirage_random.C)
-    (Netif   : Mirage_net_lwt.S)
-    (Ethif   : Mirage_protocols_lwt.ETHIF)
-    (Arpv4   : Mirage_protocols_lwt.ARP)
-    (Ipv4    : Mirage_protocols_lwt.IPV4)
-    (Icmpv4  : Mirage_protocols_lwt.ICMPV4)
-    (Udpv4   : UDPV4_DIRECT)
-    (Tcpv4   : TCPV4_DIRECT) = struct
+    (Time     : Mirage_time.S)
+    (Random   : Mirage_random.C)
+    (Netif    : Mirage_net_lwt.S)
+    (Ethernet : Mirage_protocols_lwt.ETHERNET)
+    (Arpv4    : Mirage_protocols_lwt.ARP)
+    (Ipv4     : Mirage_protocols_lwt.IPV4)
+    (Icmpv4   : Mirage_protocols_lwt.ICMPV4)
+    (Udpv4    : UDPV4_DIRECT)
+    (Tcpv4    : TCPV4_DIRECT) = struct
   type +'a io = 'a Lwt.t
   type buffer = Cstruct.t
   type ipv4addr = Ipaddr.V4.t
@@ -49,7 +49,7 @@ module Make
 
   type t = {
     netif : Netif.t;
-    ethif : Ethif.t;
+    ethif : Ethernet.t;
     arpv4 : Arpv4.t;
     ipv4  : Ipv4.t;
     icmpv4: Icmpv4.t;
@@ -60,7 +60,7 @@ module Make
   }
 
   let pp fmt t =
-    Format.fprintf fmt "mac=%s,ip=%a" (Macaddr.to_string (Ethif.mac t.ethif))
+    Format.fprintf fmt "mac=%a,ip=%a" Macaddr.pp (Ethernet.mac t.ethif)
       (Fmt.list Ipaddr.V4.pp) (Ipv4.get_ip t.ipv4)
 
   let tcpv4 { tcpv4; _ } = tcpv4
@@ -90,7 +90,7 @@ module Make
 
   let listen t =
     Log.debug (fun f -> f "Establishing or updating listener for stack %a" pp t);
-    let ethif_listener = Ethif.input
+    let ethif_listener = Ethernet.input
         ~arpv4:(Arpv4.input t.arpv4)
         ~ipv4:(
           Ipv4.input

--- a/src/stack-direct/tcpip_stack_direct.mli
+++ b/src/stack-direct/tcpip_stack_direct.mli
@@ -22,15 +22,15 @@ module type TCPV4_DIRECT = Mirage_protocols_lwt.TCPV4
   with type ipinput = direct_ipv4_input
 
 module Make
-    (Time    : Mirage_time.S)
-    (Random  : Mirage_random.C)
-    (Netif   : Mirage_net_lwt.S)
-    (Ethif   : Mirage_protocols_lwt.ETHIF)
-    (Arpv4   : Mirage_protocols_lwt.ARP)
-    (Ipv4    : Mirage_protocols_lwt.IPV4)
-    (Icmpv4  : Mirage_protocols_lwt.ICMPV4)
-    (Udpv4   : UDPV4_DIRECT)
-    (Tcpv4   : TCPV4_DIRECT) : sig
+    (Time     : Mirage_time.S)
+    (Random   : Mirage_random.C)
+    (Netif    : Mirage_net_lwt.S)
+    (Ethernet : Mirage_protocols_lwt.ETHERNET)
+    (Arpv4    : Mirage_protocols_lwt.ARP)
+    (Ipv4     : Mirage_protocols_lwt.IPV4)
+    (Icmpv4   : Mirage_protocols_lwt.ICMPV4)
+    (Udpv4    : UDPV4_DIRECT)
+    (Tcpv4    : TCPV4_DIRECT) : sig
   include Mirage_stack_lwt.V4
     with type udpv4   = Udpv4.t
      and type tcpv4   = Tcpv4.t
@@ -39,7 +39,7 @@ module Make
      and module TCPV4 = Tcpv4
      and module UDPV4 = Udpv4
 
-  val connect : Netif.t -> Ethif.t -> Arpv4.t -> Ipv4.t -> Icmpv4.t ->
+  val connect : Netif.t -> Ethernet.t -> Arpv4.t -> Ipv4.t -> Icmpv4.t ->
     Udpv4.t -> Tcpv4.t -> t Lwt.t
   (** [connect] assembles the arguments into a network stack, then calls
       `listen` on the assembled stack before returning it to the caller.  The

--- a/src/stack-unix/dune
+++ b/src/stack-unix/dune
@@ -3,7 +3,7 @@
  (public_name tcpip.icmpv4-socket)
  (modules icmpv4_socket)
  (wrapped false)
- (libraries lwt.unix ipaddr.unix cstruct-lwt io-page-unix tcpip.icmpv4
+ (libraries lwt.unix ipaddr.unix cstruct-lwt tcpip.icmpv4
    tcpip.ipv4 tcpip.ipv6 mirage-protocols-lwt))
 
 (library
@@ -49,6 +49,6 @@
  (public_name tcpip.stack-socket)
  (modules tcpip_stack_socket ipv4_socket ipv6_socket)
  (wrapped false)
- (libraries lwt.unix cstruct-lwt ipaddr.unix io-page-unix logs
+ (libraries lwt.unix cstruct-lwt ipaddr.unix logs
    tcpip.tcpv4-socket tcpip.udpv4-socket tcpip.ipv4 tcpip.ipv6 tcpip.icmpv4
    mirage-protocols-lwt mirage-stack-lwt))

--- a/src/stack-unix/ipv4_socket.ml
+++ b/src/stack-unix/ipv4_socket.ml
@@ -38,8 +38,7 @@ let connect _ = return_unit
 let input_arpv4 _ _ = fail (Failure "Not implemented")
 let input _ ~tcp:_ ~udp:_ ~default:_ _ = return_unit
 let allocate_frame _ ~dst:_ ~proto:_ = raise (Failure "Not implemented")
-let write _ _ _ = fail (Failure "Not implemented")
-let writev _ _ _ = fail (Failure "Not implemented")
+let write _ ?fragment:_ ?ttl:_ ?src:_ _ _ ?size:_ _ _ = fail (Failure "Not implemented")
 
 let get_ip _ = [Ipaddr.V4.of_string_exn "0.0.0.0"]
 let set_ip _ _ = fail (Failure "Not implemented")
@@ -48,5 +47,4 @@ let get_ip_gateways _ = raise (Failure "Not implemented")
 let set_ip_netmask _ _ = fail (Failure "Not implemented")
 let set_ip_gateways _ _ = fail (Failure "Not implemented")
 let src _ ~dst:_ = raise (Failure "Not implemented")
-let checksum _ _ = raise (Failure "Not implemented")
-let pseudoheader _ ~dst:_ ~proto:_ _ = raise (Failure "Not implemented")
+let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")

--- a/src/tcp/dune
+++ b/src/tcp/dune
@@ -2,7 +2,7 @@
  (name tcp)
  (public_name tcpip.tcp)
  (libraries logs mirage-protocols-lwt ipaddr cstruct lwt-dllist rresult
-   mirage-profile io-page tcpip duration randomconv fmt mirage-time-lwt
+   mirage-profile tcpip duration randomconv fmt mirage-time-lwt
    mirage-clock mirage-random)
  (preprocess
   (pps ppx_cstruct)))

--- a/src/udp/udp_packet.ml
+++ b/src/udp/udp_packet.ml
@@ -66,17 +66,13 @@ module Marshal = struct
   let into_cstruct ~pseudoheader ~payload t udp_buf =
     let open Udp_wire in
     let check_header_len () =
-      if (Cstruct.len udp_buf) < sizeof_udp then Error "Not enough space for a UDP header"
-      else Ok ()
+      if Cstruct.len udp_buf < sizeof_udp then
+        Error "Not enough space for a UDP header"
+      else
+        Ok ()
     in
-    let check_overall_len () =
-      let needed = sizeof_udp in
-      let provided = Cstruct.len udp_buf in
-      if provided < needed then
-        Error (Printf.sprintf "Not enough space for UDP header: provided %d, need %d" provided needed)
-      else Ok ((Cstruct.len payload) + sizeof_udp)
-    in
-    check_header_len () >>= check_overall_len >>= fun len ->
+    check_header_len () >>= fun () ->
+    let len = Cstruct.len payload + sizeof_udp in
     let buf = Cstruct.sub udp_buf 0 Udp_wire.sizeof_udp in
     unsafe_fill ~pseudoheader ~payload t buf len;
     Ok ()

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -42,7 +42,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {with-test & >= "2.0.0"}
+  "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >="0.7.0"}

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -42,7 +42,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {with-test & >= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >="0.7.0"}

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -25,14 +25,13 @@ depends: [
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.0.2"}
   "cstruct-lwt"
-  "mirage-net" {>= "1.0.0"}
-  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
   "mirage-clock" {>= "1.2.0"}
   "mirage-random" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
-  "mirage-protocols" {>= "1.4.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-protocols" {>= "2.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"
@@ -42,16 +41,15 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "io-page-unix"
   "randomconv"
-  "ethernet"
+  "ethernet" {>= "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}
-  "arp-mirage" {with-test}
+  "arp-mirage" {with-test & >= "2.0.0"}
   "lru"
 ]
 synopsis: "OCaml TCP/IP networking stack, used in MirageOS"

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executables
  (names test)
- (libraries alcotest mirage-random-test lwt.unix io-page-unix tcpip.unix logs
+ (libraries alcotest mirage-random-test lwt.unix logs
    logs.fmt mirage-profile mirage-flow mirage-vnetif mirage-clock-unix
    pcap-format duration mirage-random rresult mirage-protocols-lwt
    mirage-stack-lwt arp arp-mirage ethernet tcpip.ipv4 tcpip.tcp tcpip.udp

--- a/test/static_arp.ml
+++ b/test/static_arp.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-module Make(E : Mirage_protocols_lwt.ETHIF)(Time : Mirage_time_lwt.S) = struct
+module Make(E : Mirage_protocols_lwt.ETHERNET)(Time : Mirage_time_lwt.S) = struct
   module A = Arp.Make(E)(Time)
   (* generally repurpose A, but substitute input and query, and add functions
      for adding/deleting entries *)

--- a/test/test_deadlock.ml
+++ b/test/test_deadlock.ml
@@ -42,7 +42,7 @@ struct
 
   let make ~ip ~network ?gateway netif =
     MCLOCK.connect () >>= fun clock ->
-    ETHIF.connect ~mtu netif >>= fun ethif ->
+    ETHIF.connect netif >>= fun ethif ->
     ARPV4.connect ethif >>= fun arpv4 ->
     IPV4.connect ~ip ~network ?gateway clock ethif arpv4 >>= fun ipv4 ->
     ICMPV4.connect ipv4 >>= fun icmpv4 ->
@@ -144,8 +144,8 @@ let test_digest netif1 netif2 =
 let run_vnetif () =
   let backend = Basic_backend.Make.create
       ~use_async_readers:true ~yield:Lwt_unix.yield () in
-  TCPIP.M.NETIF.connect backend >>= fun c1 ->
-  TCPIP.M.NETIF.connect backend >>= fun c2 ->
+  TCPIP.M.NETIF.connect ~size_limit:mtu backend >>= fun c1 ->
+  TCPIP.M.NETIF.connect ~size_limit:mtu backend >>= fun c2 ->
   test_digest c1 c2
 
 let suite = [

--- a/test/test_icmpv4.ml
+++ b/test/test_icmpv4.ml
@@ -149,8 +149,8 @@ let write_errors () =
     let open Ethernet_packet in
     Unmarshal.of_cstruct buf >>= fun (ethernet_header, ethernet_payload) ->
     match ethernet_header.ethertype with
-    | Ethernet_wire.IPv6 | Ethernet_wire.ARP -> Error "not an ipv4 packet"
-    | Ethernet_wire.IPv4 ->
+    | `IPv6 | `ARP -> Error "not an ipv4 packet"
+    | `IPv4 ->
       Ipv4_packet.Unmarshal.of_cstruct ethernet_payload >>= fun (ipv4_header, ipv4_payload) ->
       Ok { ethernet_header; ethernet_payload; ipv4_header; ipv4_payload }
   in

--- a/test/test_icmpv4.ml
+++ b/test/test_icmpv4.ml
@@ -40,6 +40,8 @@ let (>>=?) = testbind
 let listener_address = Ipaddr.V4.of_string_exn "192.168.222.1"
 let speaker_address = Ipaddr.V4.of_string_exn "192.168.222.10"
 
+let header_size = Ethernet_wire.sizeof_ethernet
+
 let slowly fn =
   Time.sleep_ns (Duration.of_ms 100) >>= fun () -> fn >>= fun _ -> Time.sleep_ns (Duration.of_ms 100)
 
@@ -59,7 +61,7 @@ let get_stack ?(backend = B.create ~use_async_readers:true
 
 let icmp_listen stack fn =
   let noop = fun ~src:_ ~dst:_ _buf -> Lwt.return_unit in
-  V.listen stack.netif (* some buffer -> (unit, error) result io *)
+  V.listen stack.netif ~header_size (* some buffer -> (unit, error) result io *)
     ( E.input stack.ethif ~arpv4:(Static_arp.input stack.arp)
         ~ipv6:(fun _ -> Lwt.return_unit)
         ~ipv4:
@@ -171,7 +173,7 @@ let write_errors () =
         let open Ipv4_packet in
         Icmp.write stack.icmp ~dst:decomposed.ipv4_header.src header_and_payload >|= Rresult.R.get_ok
     in
-    V.listen stack.netif reject >|= fun _ -> ()
+    V.listen stack.netif ~header_size reject >|= fun _ -> ()
   in
   let check_packet buf : unit Lwt.t =
     let aux buf =

--- a/test/test_iperf.ml
+++ b/test/test_iperf.ml
@@ -88,7 +88,7 @@ module Test_iperf (B : Vnetif_backends.Backend) = struct
   let iperfclient s amt dest_ip dport =
     let iperftx flow =
       Logs.info (fun f -> f  "Iperf client: Made connection to server.");
-      let a = Cstruct.sub (Io_page.(to_cstruct (get 1))) 0 mlen in
+      let a = Cstruct.create mlen in
       Cstruct.blit_from_string msg 0 a 0 mlen;
       let rec loop = function
         | 0 -> Lwt.return_unit

--- a/test/test_ipv6.ml
+++ b/test/test_ipv6.ml
@@ -38,7 +38,7 @@ let get_stack backend address =
 let noop = fun ~src:_ ~dst:_ _ -> Lwt.return_unit
 
 let listen ?(tcp = noop) ?(udp = noop) ?(default = noop) stack =
-  V.listen stack.netif
+  V.listen stack.netif ~header_size:Ethernet_wire.sizeof_ethernet
     ( E.input stack.ethif
       ~arpv4:(fun _ -> Lwt.return_unit)
       ~ipv4:(fun _ -> Lwt.return_unit)

--- a/test/test_rfc5961.ml
+++ b/test/test_rfc5961.ml
@@ -325,8 +325,7 @@ let blind_syn_on_established_scenario =
   (`WAIT_FOR_SYN, fsm), sut_connects_and_remains_connected
 
 let blind_data_injection_scenario =
-  let page = Io_page.to_cstruct (Io_page.get 1) in
-  let page = Cstruct.set_len page 512 in
+  let page = Cstruct.create 512 in
   let fsm ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->
@@ -363,8 +362,7 @@ let blind_data_injection_scenario =
 
 let data_repeated_ack_scenario =
   (* This is the just data transmission with ack in the past but within the acceptable window *)
-  let page = Io_page.to_cstruct (Io_page.get 1) in
-  let page = Cstruct.set_len page 512 in
+  let page = Cstruct.create 512 in
   let fsm ip state ~src ~dst data =
     match state with
     | `WAIT_FOR_SYN ->

--- a/test/test_rfc5961.ml
+++ b/test/test_rfc5961.ml
@@ -40,6 +40,8 @@ let server_ip = Ipaddr.V4.of_string_exn "10.0.0.100"
 let netmask = 24
 let gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1")
 
+let header_size = Ethernet_wire.sizeof_ethernet
+
 (* defaults when injecting packets *)
 let options = []
 let window = 5120
@@ -86,7 +88,7 @@ let run backend fsm sut () =
       fsm_thread state in
 
   Lwt.async (fun () ->
-      (V.listen netif
+      (V.listen netif ~header_size
          (E.input
             ~arpv4:(A.input arp)
             ~ipv4:(I.input

--- a/test/vnetif_backends.ml
+++ b/test/vnetif_backends.ml
@@ -28,21 +28,14 @@ module Mtu_enforced = struct
 
   let mtu = ref 1500
 
-  let writev t id l =
-    if (Cstruct.lenv l < 14) then begin
-      Logs.err (fun f -> f "too smol");
-      Lwt.return @@ Error `Unimplemented
-    end
-    else if ((Cstruct.lenv l) - 14) > !mtu then begin
-      Logs.err (fun f -> f "tried to send a %d byte frame, but MTU is only %d" (Cstruct.lenv l) !mtu);
-      assert (((Cstruct.lenv l) - 14) <= !mtu);
-      Lwt.return @@ Error `Unimplemented (* not quite, but we're constrained to Mirage_net.error *)
-    end
-    else X.writev t id l
+  let write t id ?size fill =
+    let size' = match size with None -> !mtu | Some s -> s in
+    if size' > !mtu then
+      Lwt.return (Error `Exceeds_mtu)
+    else
+      X.write t id ?size fill
 
   let set_mtu m = mtu := m
-
-  let write t id n = writev t id [n]
 
   let create () =
     X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) ()
@@ -70,9 +63,9 @@ module Trailing_bytes : Backend = struct
         fn (add_random_bytes buf))
 
   let create () =
-    X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) () 
+    X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) ()
 
-end 
+end
 
 (** This backend drops packets *)
 module Uniform_packet_loss : Backend = struct
@@ -81,26 +74,18 @@ module Uniform_packet_loss : Backend = struct
 
   let drop_p = 0.01
 
-  let write t id buffer =
+  let write t id ?size fill =
     if Random.float 1.0 < drop_p then
       begin
         MProf.Trace.label "pkt_drop";
         Lwt.return (Ok ()) (* drop packet *)
       end else
-      X.write t id buffer (* pass to real write *)
-
-  let writev t id buffers =
-    if Random.float 1.0 < drop_p then
-      begin
-        MProf.Trace.label "pkt_drop";
-        Lwt.return (Ok ()) (* drop packet *)
-      end else
-      X.writev t id buffers (* pass to real writev *)
+      X.write t id ?size fill (* pass to real write *)
 
   let create () =
-    X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) () 
+    X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) ()
 
-end 
+end
 
 (** This backend uniformly drops packets with no payload *)
 module Uniform_no_payload_packet_loss : Backend = struct
@@ -113,22 +98,14 @@ module Uniform_no_payload_packet_loss : Backend = struct
   (* Drop probability, if no payload *)
   let drop_p = 0.10
 
-  let write t id buffer =
-    if Cstruct.len buffer <= no_payload_len && Random.float 1.0 < drop_p then
+  let write t id ?size fill =
+    let size' = match size with None -> 1500 | Some s -> s in
+    if size' <= no_payload_len && Random.float 1.0 < drop_p then
       begin
         MProf.Trace.label "pkt_drop";
         Lwt.return (Ok ()) (* drop packet *)
       end else
-      X.write t id buffer (* pass to real write *)
-
-  let writev t id buffers =
-    let total_len bufs = List.fold_left (fun a b -> a + Cstruct.len b) 0 bufs in
-    if total_len buffers <= no_payload_len && Random.float 1.0 < drop_p then
-      begin
-        MProf.Trace.label "pkt_drop";
-        Lwt.return (Ok ()) (* drop packet *)
-      end else
-      X.writev t id buffers (* pass to real writev *)
+      X.write t id ?size fill (* pass to real write *)
 
   let create () =
     X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) ()
@@ -156,7 +133,7 @@ module Drop_1_second_after_1_megabyte : Backend = struct
   let register t =
     X.register t.xt
 
-  let unregister t id = 
+  let unregister t id =
     X.unregister t.xt id
 
   let mac t id =
@@ -169,8 +146,8 @@ module Drop_1_second_after_1_megabyte : Backend = struct
     X.unregister_and_flush t.xt id
 
   let should_drop t =
-    if (t.sent_bytes > byte_limit) && 
-       (t.is_dropping = false) && 
+    if (t.sent_bytes > byte_limit) &&
+       (t.is_dropping = false) &&
        (t.done_dropping = false) then
       begin
         Logs.info (fun f -> f  "Backend dropping packets for %f sec" time_to_sleep);
@@ -191,20 +168,12 @@ module Drop_1_second_after_1_megabyte : Backend = struct
           false
       end
 
-  let write t id buffer =
-    t.sent_bytes <- t.sent_bytes + (Cstruct.len buffer);
+  let write t id ?size fill =
+    t.sent_bytes <- t.sent_bytes + (match size with None -> 1500 | Some s -> s);
     if should_drop t then
       Lwt.return (Ok ())
     else
-      X.write t.xt id buffer (* pass to real write *)
-
-  let writev t id buffers =
-    let total_len = List.fold_left (fun a b -> a + Cstruct.len b) 0 buffers in
-    t.sent_bytes <- t.sent_bytes + total_len;
-    if should_drop t then
-      Lwt.return (Ok ())
-    else
-      X.writev t.xt id buffers (* pass to real writev *)
+      X.write t.xt id ?size fill (* pass to real write *)
 
   let create () =
     let xt = X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield ()) () in
@@ -219,23 +188,14 @@ module On_off_switch = struct
 
   let send_packets = ref true
 
-  let write t id buffer =
+  let write t id ?size fill =
     if not !send_packets then
       begin
-        Logs.info (fun f -> f "write dropping 1 packet (length %d)" (Cstruct.len buffer));
+        Logs.info (fun f -> f "write dropping 1 packet");
         MProf.Trace.label "pkt_drop";
         Lwt.return (Ok ()) (* drop packet *)
       end else
-      X.write t id buffer (* pass to real write *)
-
-  let writev t id buffers =
-    if not !send_packets then
-      begin
-        Logs.info (fun f -> f "writev dropping 1 packet (length %d)" (Cstruct.lenv buffers));
-        MProf.Trace.label "pkt_drop";
-        Lwt.return (Ok ()) (* drop packet *)
-      end else
-      X.writev t id buffers (* pass to real writev *)
+      X.write t id ?size fill (* pass to real write *)
 
   let create () =
     X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) ()
@@ -248,5 +208,5 @@ module Basic : Backend = struct
   include X
 
   let create () =
-    X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) () 
+    X.create ~use_async_readers:true ~yield:(fun() -> Lwt_main.yield () ) ()
 end

--- a/test/vnetif_common.ml
+++ b/test/vnetif_common.ml
@@ -76,14 +76,11 @@ struct
     B.create ()
 
   let create_stack backend ?mtu ip netmask gw =
-    let size_limit = match mtu with
-    | None -> None
-    | Some n -> Some (n + 14)
-    in
+    let size_limit = match mtu with None -> None | Some x -> Some x in
     let network = Ipaddr.V4.Prefix.make netmask ip in
     Clock.connect () >>= fun clock ->
     V.connect ?size_limit backend >>= fun netif ->
-    E.connect ?mtu netif >>= fun ethif ->
+    E.connect netif >>= fun ethif ->
     A.connect ethif >>= fun arpv4 ->
     Ip.connect ~ip ~network ~gateway:gw clock ethif arpv4 >>= fun ipv4 ->
     Icmp.connect ipv4 >>= fun icmpv4 ->
@@ -93,8 +90,8 @@ struct
 
   let create_backend_listener backend listenf =
     match (B.register backend) with
-    | `Error _ -> failf "Error occured while registering to backend"
-    | `Ok id -> (B.set_listen_fn backend id listenf); id
+    | Error _ -> failf "Error occured while registering to backend"
+    | Ok id -> (B.set_listen_fn backend id listenf); id
 
   let disable_backend_listener backend id =
     B.unregister_and_flush backend id


### PR DESCRIPTION
this is on top of #394 and should be merged thereafter, but before a new release of tcpip. see https://github.com/mirage/mirage-protocols/pull/16