### PR TITLE
Add IPv4_packet.Unmarshal.header_of_cstruct

### DIFF
--- a/src/ipv4/ipv4_packet.mli
+++ b/src/ipv4/ipv4_packet.mli
@@ -22,6 +22,9 @@ module Unmarshal : sig
   val int_to_protocol : int -> protocol option
 
   val of_cstruct : Cstruct.t -> (t * Cstruct.t, error) result
+  val header_of_cstruct : Cstruct.t -> ((t * int), error) result
+(** [header_of_cstruct buf] attempts to return [t, offset] where [offset]
+    is the first byte of the payload in [buf]. *)
 
   val verify_transport_checksum : proto:([`TCP | `UDP]) -> ipv4_header:t ->
       transport_packet:Cstruct.t -> bool


### PR DESCRIPTION
Examining only the IPv4 packet header, without making determination
about the validity of the length field, is useful for applications which
would like to parse IPv4 headers in ICMP error payloads.