### PR TITLE
when calculating icmpv4 checksum, don't double-count the payload

### DIFF
--- a/src/icmp/icmpv4_packet.ml
+++ b/src/icmp/icmpv4_packet.ml
@@ -94,7 +94,7 @@ module Marshal = struct
     set_icmpv4_code buf code;
     set_icmpv4_csum buf 0x0000;
     subheader_into_cstruct ~buf:(Cstruct.shift buf 4) subheader;
-    let packets = [buf ; payload] in
+    let packets = [(Cstruct.sub buf 0 Icmpv4_wire.sizeof_icmpv4); payload] in
     set_icmpv4_csum buf (Tcpip_checksum.ones_complement_list packets)
 
   let check_len buf =


### PR DESCRIPTION
`into_cstruct` is likely to be passed a buffer larger than `Icmpv4_wire.sizeof_icmpv4`.  Don't consider any additional bytes in the header part of this checksum calculation, as they ought to be included with `payload` in this call.

Fixes https://github.com/mirage/qubes-mirage-firewall/issues/50 .