### PR TITLE
get rid of soon-deprecated Cstruct.set_len, use Cstruct.sub instead

### DIFF
--- a/src/stack-unix/icmpv4_socket.ml
+++ b/src/stack-unix/icmpv4_socket.ml
@@ -95,7 +95,7 @@ let listen _t addr fn =
         let receive_buffer = Cstruct.create 4096 in
         recvfrom' fd receive_buffer [] >>= fun (len, _sockaddr) ->
         (* trim the buffer to the amount of data actually received *)
-        let receive_buffer = Cstruct.set_len receive_buffer len in
+        let receive_buffer = Cstruct.sub receive_buffer 0 len in
         (* On macOS the IP length field is set to a very large value (16384) which
            probably reflects some kernel datastructure size rather than the real
            on-the-wire size. This confuses our IPv4 parser so we correct the size

--- a/src/tcp/tcp_packet.ml
+++ b/src/tcp/tcp_packet.ml
@@ -140,7 +140,7 @@ module Marshal = struct
                                                      the tcp header *)
     let options_buf = Cstruct.shift buf sizeof_tcp in
     let options_len = Options.marshal options_buf t.options in
-    let buf = Cstruct.set_len buf (sizeof_tcp + options_len) in
+    let buf = Cstruct.sub buf 0 (sizeof_tcp + options_len) in
     unsafe_fill ~pseudoheader ~payload t buf options_len;
     buf
 end


### PR DESCRIPTION
see https://github.com/mirage/ocaml-cstruct/pull/251 for further information