### PR TITLE
only handle IPv4 packets that are of interest to us (either destination ip matches or it is broadcast), remove should_reply from icmp

### DIFF
--- a/src/icmp/icmpv4.ml
+++ b/src/icmp/icmpv4.ml
@@ -32,9 +32,8 @@ module Make(IP : Mirage_protocols_lwt.IPV4) = struct
 
   let write t ~dst buf = writev t ~dst [buf]
 
-  let input t ~src ~dst buf =
+  let input t ~src ~dst:_ buf =
     let open Icmpv4_packet in
-    let should_reply t dst = List.mem dst @@ IP.get_ip t.ip in
     MProf.Trace.label "icmp_input";
     match Unmarshal.of_cstruct buf with
     | Error s ->
@@ -56,7 +55,7 @@ module Make(IP : Mirage_protocols_lwt.IPV4) = struct
         Log.debug (fun f ->
             f "ICMP echo-request received: %a (payload %a)"
               Icmpv4_packet.pp message Cstruct.hexdump_pp payload);
-        if t.echo_reply && should_reply t dst then begin
+        if t.echo_reply then begin
           let icmp = {
             code = 0x00;
             ty   = Icmpv4_wire.Echo_reply;


### PR DESCRIPTION
so I have a unikernel (mirage-skeleton/device-usage/network) using 10.0.42.2/24 as their ip address. a telnet 10.0.42.2 8080 works as expected. if I set the arp entry for 10.0.42.3 on my host to the same mac address as the unikernel, I get the following behaviour when `telnet 10.0.42.3 8080`:

tcpdump:
```
19:33:02.092900 IP 10.0.42.1.48636 > 10.0.42.3.8080: Flags [S], seq 4039916063, win 65535, options [mss 1460,nop,wscale 6,sackOK,TS val 297371683 ecr 0], length 0
19:33:02.093882 IP 10.0.42.2.8080 > 10.0.42.1.48636: Flags [S.], seq 6310731, ack 4039916064, win 65535, options [mss 1460,wscale 2,eol], length 0
19:33:02.093924 IP 10.0.42.1.48636 > 10.0.42.2.8080: Flags [R], seq 4039916064, win 0, length 0
```

unikernel output:
```
2019-04-24 17:33:02 -00:00: DBG [ipv4-fragments] process called with off 4000
2019-04-24 17:33:02 -00:00: DBG [pcb] process-syn: [channels=1 listens=1 connects=0]
2019-04-24 17:33:02 -00:00: DBG [pcb] new-server-connection: [channels=1 listens=1 connects=0]
2019-04-24 17:33:02 -00:00: DBG [state] Closed  - Passive_open -> Listen
2019-04-24 17:33:02 -00:00: DBG [state] Listen  - Send_synack(6310731) -> Syn_rcvd(6310731)
2019-04-24 17:33:02 -00:00: DBG [tcptimer] timerloop
2019-04-24 17:33:02 -00:00: DBG [tcptimer] timerloop: sleeping for 667000000 ns
2019-04-24 17:33:02 -00:00: DBG [ipv4] ip write: mtu is 1500, hdr_len is 20, size 28 payload len 0, needed_bytes 48
2019-04-24 17:33:02 -00:00: DBG [ipv4-fragments] process called with off 4000
2019-04-24 17:33:02 -00:00: DBG [pcb] process-reset: [channels=1 listens=2 connects=0]
```

after this change:
tcpdump output:
```
20:10:41.352827 IP 10.0.42.1.24337 > 10.0.42.3.8080: Flags [S], seq 2596685774, win 65535, options [mss 1460,nop,wscale 6,sackOK,TS val 1017755732 ecr 0], length 0
```

unikernel output:
```
2019-04-24 18:10:41 -00:00: DBG [ipv4] dropping IP fragment not for us or broadcast IPv4 packet 10.0.42.1 -> 10.0.42.3: id 0000, off 16384 proto 6, ttl 64, options 
```