### PR TITLE
ensure Xen bindings are built with right mirage-xen-ocaml CFLAGS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### dev
+* opam: ensure Xen bindings are built with right mirage-xen-ocaml CFLAGS (@avsm)
+
 ### v3.7.5 (2019-05-03)
 
 * drop IPv4 packets which destination address is not us or broadcast (#407 by @hannesm)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### dev
 * opam: ensure Xen bindings are built with right mirage-xen-ocaml CFLAGS (@avsm)
+* opam: correctly register mirage-xen-ocaml as a depopt (@avsm)
 
 ### v3.7.5 (2019-05-03)
 

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -14,8 +14,8 @@ tags: ["org:mirage"]
 
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs]
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -18,6 +18,7 @@ build: [
   ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
+depopts: ["mirage-xen-ocaml"]
 depends: [
   "dune"     {build & >= "1.0"}
   "configurator" {build}


### PR DESCRIPTION
Without this, the Xen checksum bindings are built with the host
CFLAGS and ABI destruction commences. Usually results in a page
fault in the Xen backend at boot time.  Fix incoming to opam-repository
as well.