### PR TITLE
introduce ipv4/Fragments.fragment : ~mtu:int -> Ipv4_packet.t -> Cstr…

### DIFF
--- a/src/ipv4/fragments.ml
+++ b/src/ipv4/fragments.ml
@@ -214,7 +214,11 @@ let fragment ~mtu hdr payload =
     let opt_size = (Cstruct.len hdr.Ipv4_packet.options + 3) / 4 * 4 in
     opt_size + Ipv4_wire.sizeof_ipv4
   in
-  let data_size = mtu - hdr_size in
-  assert (data_size mod 8 = 0);
-  assert (data_size > 0);
-  List.rev (frag1 [] hdr (Cstruct.create hdr_size) data_size data_size payload)
+  let data_size =
+    let full = mtu - hdr_size in
+    (full / 8) * 8
+  in
+  if data_size <= 0 then
+    []
+  else
+    List.rev (frag1 [] hdr (Cstruct.create hdr_size) data_size data_size payload)

--- a/src/ipv4/fragments.mli
+++ b/src/ipv4/fragments.mli
@@ -33,3 +33,5 @@ val max_duration : int64
 
 val process : Cache.t -> int64 -> Ipv4_packet.t -> Cstruct.t ->
   Cache.t * (Ipv4_packet.t * Cstruct.t) option
+
+val fragment : mtu:int -> Ipv4_packet.t -> Cstruct.t -> Cstruct.t list

--- a/src/ipv4/fragments.mli
+++ b/src/ipv4/fragments.mli
@@ -14,6 +14,37 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+(** IPv4 Fragmentation and reassembly
+
+    An IPv4 packet may exceed the maximum transferable unit (MTU) of a link, and
+   thus may be fragmented into multiple packets. Since the MTU depends on the
+   underlying link, fragmentation and reassembly may happen in gateways as well
+   as endpoints. Starting at byte 6, 16 bit in the IPv4 header are used for
+   fragmentation. The first bit is reserved, the second signals if set to never
+   fragment this packet - instead if it needs to be fragmented, an ICMP error
+   must be returned (used for path MTU discovery). The third bit indicates
+   whether this is the last fragment or more are following. The remaining 13
+   bits are the offset of this fragment in the reassembled packet, divided by
+   8. All fragments of one reassembled packet use the same 16 bit IPv4
+   identifier (byte offset 4). The IPv4 header is repeated in each fragment,
+   apart from those options which highest bit is cleared. Fragments may be
+   received in any order.
+
+    This module implements a reassembly cache, using a least recently used (LRU)
+   cache underneath. For security reasons, only non-overlapping fragments are
+   accepted. To avoid denial of service attacks, the maximum number of segments
+   is limited to 16 - with a common MTU of 1500, this means that packets
+   exceeding 24000 bytes will be dropped. The arrival time of the first and last
+   fragment may not exceed 10 seconds. There is no per-source IP limit of
+   fragment data to keep, only the total amount of fragmented data can be
+   limited by the choice of the size of the LRU.
+
+    Any received packet may be the last needed for a successful reassembly (due
+   to receiving them out-of-order). When the last fragment (which has the more
+   fragments bit cleared) for a quadruple source IP, destination IP, IP
+   identifier, and protocol ID, is received, reassembly is attempted - also on
+   subsequent packets with the same quadruple. *)
+
 module V : sig
   type t = int64 * Cstruct.t * bool * int * (int * Cstruct.t) list
   (** The type of values in the fragment cache: a timestamp of the first
@@ -43,9 +74,9 @@ val max_duration : int64
 
 val process : Cache.t -> int64 -> Ipv4_packet.t -> Cstruct.t -> Cache.t *
    (Ipv4_packet.t * Cstruct.t) option (** [process t timestamp hdr payload] is
-   [t'], a new cache, and maybe a fully reassembled IPv4 segment. If reassembly
+   [t'], a new cache, and maybe a fully reassembled IPv4 packet. If reassembly
    fails, e.g. too many fragments, delta between receive timestamp of first and
-   last segment exceeds {!max_duration}, overlapping segments, these segments
+   last packet exceeds {!max_duration}, overlapping packets, these packets
    will be dropped from the cache. The IPv4 header options are always taken from
    the first fragment (where offset is 0). If the provided IPv4 header has an
    fragmentation offset of 0, and the more fragments bit is not set, the given
@@ -57,5 +88,5 @@ val fragment : mtu:int -> Ipv4_packet.t -> Cstruct.t -> Cstruct.t list
     fragment and the remaining payload (which did not fit into the first
     fragment). The [data_length = ((mtu - header_length hdr) / 8) * 8] is used
     for each fragment (and it is assumed that the first fragment contains
-    exactly that much data). The number of segments returned is
+    exactly that much data). The number of packets returned is
     [len payload / data_len]. If [data_len <= 0], the empty list is returned. *)

--- a/src/ipv4/fragments.mli
+++ b/src/ipv4/fragments.mli
@@ -16,12 +16,20 @@
 
 module V : sig
   type t = int64 * Cstruct.t * bool * int * (int * Cstruct.t) list
+  (** The type of values in the fragment cache: a timestamp of the first
+     received one, IP options (of the first fragment), whether or not the last
+     fragment was received (the one with more fragments cleared), amount of
+     received fragments, and a list of pairs of offset and fragment. *)
 
   val weight : t -> int
+  (** [weight t] is the data length of the received fragments. *)
 end
 
 module K : sig
   type t = Ipaddr.V4.t * Ipaddr.V4.t * int * int
+  (** The type of keys in the fragment cache: source IP address, destination
+      IP address, protocol type, and IP identifier. *)
+
   val compare : t -> t -> int
 end
 
@@ -30,8 +38,24 @@ module Cache : sig
 end
 
 val max_duration : int64
+(** [max_duration] is the maximum delta between first and last received
+    fragment, in nanoseconds. At the moment it is 10 seconds. *)
 
-val process : Cache.t -> int64 -> Ipv4_packet.t -> Cstruct.t ->
-  Cache.t * (Ipv4_packet.t * Cstruct.t) option
+val process : Cache.t -> int64 -> Ipv4_packet.t -> Cstruct.t -> Cache.t *
+   (Ipv4_packet.t * Cstruct.t) option (** [process t timestamp hdr payload] is
+   [t'], a new cache, and maybe a fully reassembled IPv4 segment. If reassembly
+   fails, e.g. too many fragments, delta between receive timestamp of first and
+   last segment exceeds {!max_duration}, overlapping segments, these segments
+   will be dropped from the cache. The IPv4 header options are always taken from
+   the first fragment (where offset is 0). If the provided IPv4 header has an
+   fragmentation offset of 0, and the more fragments bit is not set, the given
+   header and payload is directly returned. Handles out-of-order fragments
+   gracefully. *)
 
 val fragment : mtu:int -> Ipv4_packet.t -> Cstruct.t -> Cstruct.t list
+(** [fragment ~mtu hdr payload] is called with the IPv4 header of the first
+    fragment and the remaining payload (which did not fit into the first
+    fragment). The [data_length = ((mtu - header_length hdr) / 8) * 8] is used
+    for each fragment (and it is assumed that the first fragment contains
+    exactly that much data). The number of segments returned is
+    [len payload / data_len]. If [data_len <= 0], the empty list is returned. *)


### PR DESCRIPTION
…uct.t -> Cstruct.t list

a function that takes the MTU, an IPv4 header, and a payload, and returns a list
of IPv4 segments to be sent out. This is to-be-called with the remaining payload
after the first segment. Use this function in Static_ipv4.write.

For what its worth: >95% of IPv4 packets are not fragmented, i.e. it is crucial
that the fast path (no fragmentation) does least allocation!
In contrast to earlier code, this now copies the payload (Cstruct.concat rest)
before passing to Fragments.fragment (which copies once more
(Cstruct.append hdr payload), and then the call to writeout blits it into the
network-device allocated storage).

It is also slightly incorrect (in the more general setting where
Fragments.fragment is used from elsewhere with an Ipv4_packet.t that contains
options (which shouldn't be copied)) (requires a different representation of
options -- a list of (bool * Cstruct.t) where the bool is the first bit
(indicating whether to copy the option (or not) into following IPv4 fragments)).

//cc @yomimono @linse @cfcs
https://github.com/mirage/mirage-nat/issues/31
https://github.com/mirage/qubes-mirage-firewall/issues/73