### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/tcpip.opam
+++ b/tcpip.opam
@@ -20,7 +20,7 @@ build: [
 
 depopts: ["mirage-xen-ocaml"]
 depends: [
-  "dune"     {build & >= "1.0"}
+  "dune"     {>= "1.0"}
   "ocaml" {>= "4.03.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.