### PR TITLE
Ipv4.Fragments: use a mutable LRU cache (Lru.M.t instead of mutable cache : Lru.F.t)

### DIFF
--- a/src/ipv4/fragments.mli
+++ b/src/ipv4/fragments.mli
@@ -45,43 +45,33 @@
    identifier, and protocol ID, is received, reassembly is attempted - also on
    subsequent packets with the same quadruple. *)
 
-module V : sig
-  type t = int64 * Cstruct.t * bool * int * (int * Cstruct.t) list
-  (** The type of values in the fragment cache: a timestamp of the first
-     received one, IP options (of the first fragment), whether or not the last
-     fragment was received (the one with more fragments cleared), amount of
-     received fragments, and a list of pairs of offset and fragment. *)
+module V : Lru.Weighted with type t = int64 * Cstruct.t * bool * int * (int * Cstruct.t) list
+(** The type of values in the fragment cache: a timestamp of the first
+    received one, IP options (of the first fragment), whether or not the last
+    fragment was received (the one with more fragments cleared), amount of
+    received fragments, and a list of pairs of offset and fragment. *)
 
-  val weight : t -> int
-  (** [weight t] is the data length of the received fragments. *)
-end
+module K : Hashtbl.SeededHashedType
+  with type t = Ipaddr.V4.t * Ipaddr.V4.t * int * int
+(** The type of keys in the fragment cache: source IP address, destination
+    IP address, protocol type, and IP identifier. *)
 
-module K : sig
-  type t = Ipaddr.V4.t * Ipaddr.V4.t * int * int
-  (** The type of keys in the fragment cache: source IP address, destination
-      IP address, protocol type, and IP identifier. *)
-
-  val compare : t -> t -> int
-end
-
-module Cache : sig
-  include Lru.F.S with type k = K.t and type v = V.t
-end
+module Cache : Lru.M.S with type k = K.t and type v = V.t
 
 val max_duration : int64
 (** [max_duration] is the maximum delta between first and last received
     fragment, in nanoseconds. At the moment it is 10 seconds. *)
 
-val process : Cache.t -> int64 -> Ipv4_packet.t -> Cstruct.t -> Cache.t *
-   (Ipv4_packet.t * Cstruct.t) option (** [process t timestamp hdr payload] is
-   [t'], a new cache, and maybe a fully reassembled IPv4 packet. If reassembly
-   fails, e.g. too many fragments, delta between receive timestamp of first and
-   last packet exceeds {!max_duration}, overlapping packets, these packets
-   will be dropped from the cache. The IPv4 header options are always taken from
-   the first fragment (where offset is 0). If the provided IPv4 header has an
-   fragmentation offset of 0, and the more fragments bit is not set, the given
-   header and payload is directly returned. Handles out-of-order fragments
-   gracefully. *)
+val process : Cache.t -> int64 -> Ipv4_packet.t -> Cstruct.t ->
+  (Ipv4_packet.t * Cstruct.t) option
+(** [process t timestamp hdr payload] is [t'], a new cache, and maybe a fully
+    reassembled IPv4 packet. If reassembly fails, e.g. too many fragments, delta
+    between receive timestamp of first and last packet exceeds {!max_duration},
+    overlapping packets, these packets will be dropped from the cache. The IPv4
+    header options are always taken from the first fragment (where offset is
+    0). If the provided IPv4 header has an fragmentation offset of 0, and the
+    more fragments bit is not set, the given header and payload is directly
+    returned. Handles out-of-order fragments gracefully. *)
 
 val fragment : mtu:int -> Ipv4_packet.t -> Cstruct.t -> Cstruct.t list
 (** [fragment ~mtu hdr payload] is called with the IPv4 header of the first

--- a/src/ipv4/static_ipv4.ml
+++ b/src/ipv4/static_ipv4.ml
@@ -43,7 +43,7 @@ module Make (R: Mirage_random.C) (C: Mirage_clock.MCLOCK) (Ethernet: Mirage_prot
     mutable ip: Ipaddr.V4.t;
     network: Ipaddr.V4.Prefix.t;
     mutable gateway: Ipaddr.V4.t option;
-    mutable cache: Fragments.Cache.t;
+    cache: Fragments.Cache.t;
   }
 
   let write t ?(fragment = true) ?(ttl = 38) ?src dst proto ?(size = 0) headerf bufs =
@@ -151,9 +151,7 @@ module Make (R: Mirage_random.C) (C: Mirage_clock.MCLOCK) (Ethernet: Mirage_prot
         Lwt.return_unit
       end else
         let ts = C.elapsed_ns t.clock in
-        let cache, res = Fragments.process t.cache ts packet payload in
-        t.cache <- cache ;
-        match res with
+        match Fragments.process t.cache ts packet payload with
         | None -> Lwt.return_unit
         | Some (packet, payload) ->
           let src, dst = packet.src, packet.dst in
@@ -175,7 +173,7 @@ module Make (R: Mirage_random.C) (C: Mirage_clock.MCLOCK) (Ethernet: Mirage_prot
       Arpv4.set_ips arp [ip] >>= fun () ->
       (* TODO currently hardcoded to 256KB, should be configurable
          and maybe limited per-src/dst-ip as well? *)
-      let cache = Fragments.Cache.empty (1024 * 256) in
+      let cache = Fragments.Cache.create ~random:true (1024 * 256) in
       let t = { ethif; arp; ip; clock; network; gateway ; cache } in
       Lwt.return t
 


### PR DESCRIPTION
- is faster (O(1) instead of O(log n))
- still avoids (due to randomization) collision-based complexity

as suggested by @pqwy in https://github.com/mirage/mirage-nat/pull/28#issuecomment-482619504 (see as well the brief overview of Lru at https://pqwy.github.io/lru/doc/lru/Lru/index.html)

it also simplifies the API of the Fragments module, and makes it easier to use! :)