### PR TITLE
tcp: ignore result of xmit, continues #310, see #392

### DIFF
--- a/src/tcp/segment.ml
+++ b/src/tcp/segment.ml
@@ -307,7 +307,10 @@ module Tx (Time:Mirage_time.S) (Clock:Mirage_clock.MCLOCK) = struct
                   fmt "TCP retransmission triggered by timer! seq = %d"
                     (Sequence.to_int rexmit_seg.seq));
               Lwt.async
-                (fun () -> xmit ~flags ~wnd ~options ~seq rexmit_seg.data);
+                (fun () ->
+                   xmit ~flags ~wnd ~options ~seq rexmit_seg.data
+                   (* TODO should this return value really be ignored? *)
+                   >|= fun (_: ('a,'b) result) -> () );
               Window.alert_fast_rexmit wnd rexmit_seg.seq;
               Window.backoff_rto wnd;
               Log.debug (fun fmt -> fmt "Backed off! %a" Window.pp wnd);

--- a/test/test_rfc5961.ml
+++ b/test/test_rfc5961.ml
@@ -100,7 +100,7 @@ let run backend fsm sut () =
             ~ipv6:(fun _buf ->
               Logs.debug (fun f -> f "IPv6 packet -- dropping");
               Lwt.return_unit)
-            ethif) ));
+            ethif) ) >|= fun _ -> ());
 
   (* Either both fsm and the sut terminates, or a timeout occurs, or one of the sut/fsm informs an error *)
   Lwt.pick [


### PR DESCRIPTION
CI is failing since lwt >= 5 is installed, but the TCP code is not yet ready for this. #310 had a partial fix (`Lwt.async` now demands a `unit Lwt.t` result type), while this applies the same patch to the other call site of `xmit`.