### PR TITLE
fix Ipv6 code

### DIFF
--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -90,7 +90,8 @@ module Make (E : Mirage_protocols.ETHERNET)
 
   let input t ~tcp ~udp ~default buf =
     let now = C.elapsed_ns () in
-    let _, outs, actions = Ndpv6.handle ~now ~random:R.generate t.ctx buf in
+    let ctx, outs, actions = Ndpv6.handle ~now ~random:R.generate t.ctx buf in
+    t.ctx <- ctx;
     Lwt_list.iter_s (function
         | `Tcp (src, dst, buf) -> tcp ~src ~dst buf
         | `Udp (src, dst, buf) -> udp ~src ~dst buf

--- a/src/ipv6/ndpv6.ml
+++ b/src/ipv6/ndpv6.ml
@@ -164,6 +164,7 @@ module Allocate = struct
       Ipv6_wire.set_ipv6_nhdr ipbuf (Ipv6_wire.protocol_to_int proto);
       let hdr, payload = Cstruct.split ipbuf Ipv6_wire.sizeof_ipv6 in
       let len' = fillf hdr payload in
+      Ipv6_wire.set_ipv6_len ipbuf len';
       assert (len' <= size') ;
       len' + Ipv6_wire.sizeof_ipv6
     in

--- a/src/ipv6/ndpv6.ml
+++ b/src/ipv6/ndpv6.ml
@@ -234,8 +234,8 @@ module Allocate = struct
       Ipv6_wire.set_pingv6_id icmpbuf id;
       Ipv6_wire.set_pingv6_seq icmpbuf seq;
       Ipv6_wire.set_pingv6_csum icmpbuf 0;
-      Ipv6_wire.set_pingv6_csum icmpbuf @@ checksum hdr (icmpbuf :: data :: []);
       Cstruct.blit data 0 icmpbuf Ipv6_wire.sizeof_pingv6 (Cstruct.len data);
+      Ipv6_wire.set_pingv6_csum icmpbuf @@ checksum hdr [ icmpbuf ];
       size
     in
     hdr ~src ~dst ~hlim ~proto:`ICMP ~size fillf

--- a/src/ipv6/ndpv6.ml
+++ b/src/ipv6/ndpv6.ml
@@ -165,7 +165,6 @@ module Allocate = struct
       Ipv6_wire.set_ipv6_nhdr ipbuf (Ipv6_wire.protocol_to_int proto);
       let hdr, payload = Cstruct.split ipbuf Ipv6_wire.sizeof_ipv6 in
       let len' = fillf hdr payload in
-      assert (len' = size) ;
       len' + Ipv6_wire.sizeof_ipv6
     in
     (size', fill)

--- a/src/ipv6/ndpv6.ml
+++ b/src/ipv6/ndpv6.ml
@@ -158,14 +158,14 @@ module Allocate = struct
     let size' = size + Ipv6_wire.sizeof_ipv6 in
     let fill ipbuf =
       Ipv6_wire.set_ipv6_version_flow ipbuf 0x60000000l; (* IPv6 *)
+      Ipv6_wire.set_ipv6_len ipbuf size;
       ipaddr_to_cstruct_raw src (Ipv6_wire.get_ipv6_src ipbuf) 0;
       ipaddr_to_cstruct_raw dst (Ipv6_wire.get_ipv6_dst ipbuf) 0;
       Ipv6_wire.set_ipv6_hlim ipbuf hlim;
       Ipv6_wire.set_ipv6_nhdr ipbuf (Ipv6_wire.protocol_to_int proto);
       let hdr, payload = Cstruct.split ipbuf Ipv6_wire.sizeof_ipv6 in
       let len' = fillf hdr payload in
-      Ipv6_wire.set_ipv6_len ipbuf len';
-      assert (len' <= size') ;
+      assert (len' = size) ;
       len' + Ipv6_wire.sizeof_ipv6
     in
     (size', fill)

--- a/test/test.ml
+++ b/test/test.ml
@@ -25,9 +25,9 @@ let suite = [
   "mtu+tcp"        , Test_mtus.suite        ;
   "rfc5961"        , Test_rfc5961.suite     ;
   "socket"         , Test_socket.suite      ;
-  "connect"        , Test_connect.suite     ;
+  (* "connect"        , Test_connect.suite     ;*)
   "deadlock"       , Test_deadlock.suite    ;
-  "iperf"          , Test_iperf.suite       ;
+  (* "iperf"          , Test_iperf.suite       ;*)
   "keepalive"      , Test_keepalive.suite   ;
 ]
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -27,7 +27,7 @@ let suite = [
   "socket"         , Test_socket.suite      ;
   "connect"        , Test_connect.suite     ;
   "deadlock"       , Test_deadlock.suite    ;
-  (* "iperf"          , Test_iperf.suite       ;*)
+  "iperf"          , Test_iperf.suite       ;
   "keepalive"      , Test_keepalive.suite   ;
 ]
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -25,7 +25,7 @@ let suite = [
   "mtu+tcp"        , Test_mtus.suite        ;
   "rfc5961"        , Test_rfc5961.suite     ;
   "socket"         , Test_socket.suite      ;
-  (* "connect"        , Test_connect.suite     ;*)
+  "connect"        , Test_connect.suite     ;
   "deadlock"       , Test_deadlock.suite    ;
   (* "iperf"          , Test_iperf.suite       ;*)
   "keepalive"      , Test_keepalive.suite   ;
@@ -35,6 +35,7 @@ let run test () =
   Lwt_main.run (test ())
 
 let () =
+  Printexc.record_backtrace true;
   (* someone has to call Mirage_random_test.initialize () *)
   Mirage_random_test.initialize ();
   (* enable logging to stdout for all modules *)

--- a/test/test_ipv6.ml
+++ b/test/test_ipv6.ml
@@ -52,7 +52,6 @@ let udp_message = (Cstruct.of_string "hello on UDP over IPv6")
 let check_for_one_udp_packet on_received_one ~src ~dst buf =
   (match Udp_packet.Unmarshal.of_cstruct buf with
   | Ok (_, payload) ->
-    Printf.fprintf stderr "Receiver got UDP from src=%s dst=%s payload='%s'\n%!" (Ipaddr.V6.to_string src) (Ipaddr.V6.to_string dst) (Cstruct.to_string payload); 
     Alcotest.(check ip) "sender address" (Ipaddr.V6.of_string_exn "fc00::23") src;
     Alcotest.(check ip) "receiver address" (Ipaddr.V6.of_string_exn "fc00::45") dst;
     Alcotest.(check cstruct) "payload is correct" udp_message payload

--- a/test/test_ipv6.ml
+++ b/test/test_ipv6.ml
@@ -47,7 +47,7 @@ let listen ?(tcp = noop) ?(udp = noop) ?(default = noop) stack =
           ~udp:udp
           ~default:(fun ~proto:_ -> default))) >>= fun _ -> Lwt.return_unit
 
-let udp_message = (Cstruct.of_string "hello on UDP over IPv6")
+let udp_message = Cstruct.of_string "hello on UDP over IPv6"
 
 let check_for_one_udp_packet on_received_one ~src ~dst buf =
   (match Udp_packet.Unmarshal.of_cstruct buf with
@@ -62,7 +62,7 @@ let check_for_one_udp_packet on_received_one ~src ~dst buf =
 let send_forever sender receiver_address udp_message =
   let rec loop () =
     (* Check that we have an IP before sending *)
-    if (List.length (Ipv6.get_ip sender.ip)) >= 1 then
+    if List.length (Ipv6.get_ip sender.ip) >= 1 then
     begin
             Udp.write sender.udp ~dst:receiver_address ~dst_port:1234 udp_message
             >|= Rresult.R.get_ok

--- a/test/test_mtus.ml
+++ b/test/test_mtus.ml
@@ -5,7 +5,7 @@ let client_cidr = Ipaddr.V4.Prefix.of_string_exn "192.168.1.10/24"
 
 let server_port = 7
 
-module Backend = Vnetif_backends.Mtu_enforced
+module Backend = Vnetif_backends.Frame_size_enforced
 module Stack = Vnetif_common.VNETIF_STACK(Backend)
 
 let default_mtu = 1500
@@ -36,7 +36,7 @@ let get_stacks ?client_mtu ?server_mtu backend =
   Stack.create_stack ~cidr:client_cidr ~mtu:client_mtu backend >>= fun client ->
   Stack.create_stack ~cidr:server_cidr ~mtu:server_mtu backend >>= fun server ->
   let max_mtu = max client_mtu server_mtu in
-  Backend.set_mtu max_mtu;
+  Backend.set_max_ip_mtu backend max_mtu;
   Lwt.return (server, client)
 
 let start_server ~f server =


### PR DESCRIPTION
I was curious what the current state of MirageOS and IPv6 is (a question coming up every now and then). Thus I tried with link-local addresses the mirage-skeleton example device-usage/ping6, and discovered:
- bad IPv6 packets (the length field was never set due to some changes by myself when migrating the API to mirage-net 2.0)
- the ctx (contaning the neighbour cache etc.) was not stored/assigned when Ndpv6.handle was called
- the pong packets had bad checksum (again, issue introduced by myself when migrating API)

with these changes, the ping6 example boots and replies to icmpv6 echo requests. This is great progress IMHO (but there's likely some more stuff to fix/enhance before MirageOS is IPv6 ready).

Any reviews are appreciated.