### PR TITLE
IPv6 stack support

### DIFF
--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -140,3 +140,119 @@ module Make
     (match t.task with None -> () | Some task -> Lwt.cancel task);
     Lwt.return_unit
 end
+
+type direct_ipv6_input = src:Ipaddr.V6.t -> dst:Ipaddr.V6.t -> Cstruct.t -> unit Lwt.t
+module type UDPV6_DIRECT = Mirage_protocols.UDP
+  with type ipaddr = Ipaddr.V6.t
+   and type ipinput = direct_ipv6_input
+
+module type TCPV6_DIRECT = Mirage_protocols.TCP
+  with type ipaddr = Ipaddr.V6.t
+   and type ipinput = direct_ipv6_input
+
+module MakeV6
+    (Time     : Mirage_time.S)
+    (Random   : Mirage_random.S)
+    (Netif    : Mirage_net.S)
+    (Ethernet : Mirage_protocols.ETHERNET)
+    (Ipv6     : Mirage_protocols.IP with type ipaddr = Ipaddr.V6.t)
+    (Udpv6    : UDPV6_DIRECT)
+    (Tcpv6    : TCPV6_DIRECT) = struct
+
+  module UDP = Udpv6
+  module TCP = Tcpv6
+  module IP  = Ipv6
+
+  type t = {
+    netif : Netif.t;
+    ethif : Ethernet.t;
+    ipv6  : Ipv6.t;
+    udpv6 : Udpv6.t;
+    tcpv6 : Tcpv6.t;
+    udpv6_listeners: (int, Udpv6.callback) Hashtbl.t;
+    tcpv6_listeners: (int, Tcpv6.listener) Hashtbl.t;
+    mutable task : unit Lwt.t option;
+  }
+
+  let pp fmt t =
+    Format.fprintf fmt "mac=%a,ip=%a" Macaddr.pp (Ethernet.mac t.ethif)
+      (Fmt.list Ipaddr.V6.pp) (Ipv6.get_ip t.ipv6)
+
+  let tcp { tcpv6; _ } = tcpv6
+  let udp { udpv6; _ } = udpv6
+  let ip { ipv6; _ } = ipv6
+
+  let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p
+
+  let listen_udp t ~port callback =
+    if port < 0 || port > 65535
+    then raise (Invalid_argument (err_invalid_port port))
+    else Hashtbl.replace t.udpv6_listeners port callback
+
+  let listen_tcp ?keepalive t ~port process =
+    if port < 0 || port > 65535
+    then raise (Invalid_argument (err_invalid_port port))
+    else Hashtbl.replace t.tcpv6_listeners port { Tcpv6.process; keepalive }
+
+  let udpv6_listeners t ~dst_port =
+    try Some (Hashtbl.find t.udpv6_listeners dst_port)
+    with Not_found -> None
+
+  let tcpv6_listeners t dst_port =
+    try Some (Hashtbl.find t.tcpv6_listeners dst_port)
+    with Not_found -> None
+
+  let listen t =
+    Lwt.catch (fun () ->
+        Log.debug (fun f -> f "Establishing or updating listener for stack %a" pp t);
+        let ethif_listener = Ethernet.input
+            ~arpv4:(fun _ -> Lwt.return_unit)
+            ~ipv4:(fun _ -> Lwt.return_unit)
+            ~ipv6:(
+              Ipv6.input
+                ~tcp:(Tcpv6.input t.tcpv6
+                      ~listeners:(tcpv6_listeners t))
+                ~udp:(Udpv6.input t.udpv6
+                      ~listeners:(udpv6_listeners t))
+                ~default:(fun ~proto:_ ~src:_ ~dst:_ _ -> Lwt.return_unit)
+                t.ipv6)
+            t.ethif
+        in
+        Netif.listen t.netif ~header_size:Ethernet_wire.sizeof_ethernet ethif_listener
+        >>= function
+        | Error e ->
+          Log.warn (fun p -> p "%a" Netif.pp_error e) ;
+          (* XXX: error should be passed to the caller *)
+          Lwt.return_unit
+        | Ok _res ->
+          let nstat = Netif.get_stats_counters t.netif in
+          let open Mirage_net in
+          Log.info (fun f ->
+              f "listening loop of interface %s terminated regularly:@ %Lu bytes \
+                 (%lu packets) received, %Lu bytes (%lu packets) sent@ "
+                (Macaddr.to_string (Netif.mac t.netif))
+                nstat.rx_bytes nstat.rx_pkts
+                nstat.tx_bytes nstat.tx_pkts) ;
+          Lwt.return_unit)
+      (function
+        | Lwt.Canceled ->
+          Log.info (fun f -> f "listen of %a cancelled" pp t);
+          Lwt.return_unit
+        | e -> Lwt.fail e)
+
+  let connect netif ethif ipv6 udpv6 tcpv6 =
+    let udpv6_listeners = Hashtbl.create 7 in
+    let tcpv6_listeners = Hashtbl.create 7 in
+    let t = { netif; ethif; ipv6; tcpv6; udpv6;
+              udpv6_listeners; tcpv6_listeners; task = None } in
+    Log.info (fun f -> f "stack assembled: %a" pp t);
+    Lwt.async (fun () -> let task = listen t in t.task <- Some task; task);
+    Lwt.return t
+
+  let disconnect t =
+    Log.info (fun f -> f "disconnect called: %a" pp t);
+    (match t.task with None -> () | Some task -> Lwt.cancel task);
+    Lwt.return_unit
+
+end
+

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.1.0"}
   "mirage-protocols" {>= "4.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/test/test.ml
+++ b/test/test.ml
@@ -26,6 +26,7 @@ let suite = [
   "rfc5961"        , Test_rfc5961.suite     ;
   "socket"         , Test_socket.suite      ;
   "connect"        , Test_connect.suite     ;
+  "connect_ipv6"        , Test_connect_ipv6.suite     ;
   "deadlock"       , Test_deadlock.suite    ;
   "iperf"          , Test_iperf.suite       ;
   "keepalive"      , Test_keepalive.suite   ;

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,6 +29,7 @@ let suite = [
   "connect_ipv6"        , Test_connect_ipv6.suite     ;
   "deadlock"       , Test_deadlock.suite    ;
   "iperf"          , Test_iperf.suite       ;
+  "iperf_ipv6"     , Test_iperf_ipv6.suite       ;
   "keepalive"      , Test_keepalive.suite   ;
 ]
 

--- a/test/test_connect_ipv6.ml
+++ b/test/test_connect_ipv6.ml
@@ -121,7 +121,8 @@ let suite = [
   "connect two stacks, uniform packet loss of packets with no payload x 100", `Slow,
   test_tcp_connect_two_stacks_x100_uniform_no_payload_packet_loss;
 
+  (* TODO Reenable when test succeeds: 
   "connect two stacks, with trailing bytes", `Quick,
-  test_tcp_connect_two_stacks_trailing_bytes;
+  test_tcp_connect_two_stacks_trailing_bytes;*)
 
 ]

--- a/test/test_connect_ipv6.ml
+++ b/test/test_connect_ipv6.ml
@@ -121,8 +121,7 @@ let suite = [
   "connect two stacks, uniform packet loss of packets with no payload x 100", `Slow,
   test_tcp_connect_two_stacks_x100_uniform_no_payload_packet_loss;
 
-  (* TODO Reenable when test succeeds: 
   "connect two stacks, with trailing bytes", `Quick,
-  test_tcp_connect_two_stacks_trailing_bytes;*)
+  test_tcp_connect_two_stacks_trailing_bytes;
 
 ]

--- a/test/test_connect_ipv6.ml
+++ b/test/test_connect_ipv6.ml
@@ -1,0 +1,127 @@
+(*
+ * Copyright (c) 2015 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Common
+open Vnetif_common
+
+let (>>=) = Lwt.(>>=)
+
+let src = Logs.Src.create "test_connect" ~doc:"connect tests"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Test_connect_ipv6 (B : Vnetif_backends.Backend) = struct
+  module V = VNETIF_STACK (B)
+
+  let client_address = Ipaddr.V6.of_string_exn "fc00::23"
+  let server_address = Ipaddr.V6.of_string_exn "fc00::45"
+  let test_string = "Hello world from Mirage 123456789...."
+  let backend = V.create_backend ()
+
+  let err_read_eof () = failf "accept got EOF while reading"
+  let err_write_eof () = failf "client tried to write, got EOF"
+
+  let err_read e =
+    let err = Format.asprintf "%a" V.Stackv6.TCP.pp_error e in
+    failf "Error while reading: %s" err
+
+  let err_write e =
+    let err = Format.asprintf "%a" V.Stackv6.TCP.pp_write_error e in
+    failf "client tried to write, got %s" err
+
+  let accept flow expected =
+    let ip, port = V.Stackv6.TCP.dst flow in
+    Log.debug (fun f -> f "Accepted connection from %s:%d" (Ipaddr.V6.to_string ip) port);
+    V.Stackv6.TCP.read flow >>= function
+    | Error e      -> err_read e
+    | Ok `Eof      -> err_read_eof ()
+    | Ok (`Data b) ->
+      Lwt_unix.sleep 0.1 >>= fun () ->
+      (* sleep first to capture data in pcap *)
+      Alcotest.(check string) "accept" expected (Cstruct.to_string b);
+      Log.debug (fun f -> f "Connection closed");
+      Lwt.return_unit
+
+  let test_tcp_connect_two_stacks () =
+    let timeout = 15.0 in
+    Lwt.pick [
+      (Lwt_unix.sleep timeout >>= fun () ->
+       failf "connect test timedout after %f seconds" timeout) ;
+
+      (V.create_stack_v6 ~ip:[server_address] backend >>= fun s1 ->
+       V.Stackv6.listen_tcp s1 ~port:80 (fun f -> accept f test_string);
+       V.Stackv6.listen s1) ;
+
+      (Lwt_unix.sleep 0.1 >>= fun () ->
+       V.create_stack_v6 ~ip:[client_address] backend >>= fun s2 ->
+       Lwt.pick [
+       V.Stackv6.listen s2;
+       (let conn = V.Stackv6.TCP.create_connection (V.Stackv6.tcp s2) in
+       or_error "connect" conn (server_address, 80) >>= fun flow ->
+       Log.debug (fun f -> f "Connected to other end...");
+
+       V.Stackv6.TCP.write flow (Cstruct.of_string test_string) >>= function
+       | Error `Closed -> err_write_eof ()
+       | Error e -> err_write e
+       | Ok ()   ->
+         Log.debug (fun f -> f "wrote hello world");
+         V.Stackv6.TCP.close flow >>= fun () ->
+         Lwt_unix.sleep 1.0 >>= fun () -> (* record some traffic after close *)
+         Lwt.return_unit)]) ] >>= fun () ->
+
+    Lwt.return_unit
+
+  let record_pcap =
+    V.record_pcap backend
+
+end
+
+let test_tcp_connect_two_stacks_basic () =
+  let module Test = Test_connect_ipv6(Vnetif_backends.Basic) in
+  Test.record_pcap
+    "tcp_connect_ipv6_two_stacks_basic.pcap"
+    Test.test_tcp_connect_two_stacks
+
+let test_tcp_connect_two_stacks_x100_uniform_no_payload_packet_loss () =
+  let rec loop = function
+      | 0 -> Lwt.return_unit
+      | n -> Log.info (fun f -> f "%d/100" (101-n));
+             let module Test = Test_connect_ipv6(Vnetif_backends.Uniform_no_payload_packet_loss) in
+             Test.record_pcap
+               (Printf.sprintf
+               "tcp_connect_ipv6_two_stacks_no_payload_packet_loss_%d_of_100.pcap" n)
+               Test.test_tcp_connect_two_stacks >>= fun () ->
+             loop (n - 1)
+  in
+  loop 100
+
+let test_tcp_connect_two_stacks_trailing_bytes () =
+  let module Test = Test_connect_ipv6(Vnetif_backends.Trailing_bytes) in
+  Test.record_pcap
+    "tcp_connect_ipv6_two_stacks_trailing_bytes.pcap"
+    Test.test_tcp_connect_two_stacks
+
+let suite = [
+
+  "connect two stacks, basic test", `Quick,
+  test_tcp_connect_two_stacks_basic;
+
+  "connect two stacks, uniform packet loss of packets with no payload x 100", `Slow,
+  test_tcp_connect_two_stacks_x100_uniform_no_payload_packet_loss;
+
+  "connect two stacks, with trailing bytes", `Quick,
+  test_tcp_connect_two_stacks_trailing_bytes;
+
+]

--- a/test/test_iperf_ipv6.ml
+++ b/test/test_iperf_ipv6.ml
@@ -1,0 +1,268 @@
+(*
+ * Copyright (c) 2011 Richard Mortier <mort@cantab.net>
+ * Copyright (c) 2012 Balraj Singh <balraj.singh@cl.cam.ac.uk>
+ * Copyright (c) 2015 Magnus Skjegstad <magnus@skjegstad.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Common
+open Vnetif_common
+open Lwt.Infix
+
+module Test_iperf_ipv6 (B : Vnetif_backends.Backend) = struct
+
+  module V = VNETIF_STACK (B)
+
+  let client_ip = Ipaddr.V6.of_string_exn "fc00::23"
+  let server_ip =  Ipaddr.V6.of_string_exn "fc00::45"
+
+  type stats = {
+    mutable bytes: int64;
+    mutable packets: int64;
+    mutable bin_bytes:int64;
+    mutable bin_packets: int64;
+    mutable start_time: int64;
+    mutable last_time: int64;
+  }
+
+  type network = {
+    backend : B.t;
+    server : V.Stackv6.t;
+    client : V.Stackv6.t;
+  }
+
+  let default_network ?mtu ?(backend = B.create ()) () =
+      V.create_stack_v6 ?mtu ?ip:(Some [client_ip]) backend >>= fun client ->
+      V.create_stack_v6 ?mtu ?ip:(Some [server_ip]) backend >>= fun server ->
+      Lwt.return {backend; server; client}
+
+  let msg =
+    let m = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" in
+    let rec build l = function
+            | 0 -> l
+            | n -> build (m :: l) (n - 1)
+    in
+    String.concat "" @@ build [] 60
+
+  let mlen = String.length msg
+
+  let err_eof () = failf "EOF while writing to TCP flow"
+
+  let err_connect e ip port () =
+    let err = Format.asprintf "%a" V.Stackv6.TCP.pp_error e in
+    let ip  = Ipaddr.V6.to_string ip in
+    failf "Unable to connect to %s:%d: %s" ip port err
+
+  let err_write e () =
+    let err = Format.asprintf "%a" V.Stackv6.TCP.pp_write_error e in
+    failf "Error while writing to TCP flow: %s" err
+
+  let err_read e () =
+    let err = Format.asprintf "%a" V.Stackv6.TCP.pp_error e in
+    failf "Error in server while reading: %s" err
+
+  let write_and_check flow buf =
+    V.Stackv6.TCP.write flow buf >>= function
+    | Ok ()          -> Lwt.return_unit
+    | Error `Closed -> V.Stackv6.TCP.close flow >>= err_eof
+    | Error e -> V.Stackv6.TCP.close flow >>= err_write e
+
+  let tcp_connect t (ip, port) =
+    V.Stackv6.TCP.create_connection t (ip, port) >>= function
+    | Error e -> err_connect e ip port ()
+    | Ok f    -> Lwt.return f
+
+  let iperfclient s amt dest_ip dport =
+    let iperftx flow =
+      Logs.info (fun f -> f  "Iperf client: Made connection to server.");
+      let a = Cstruct.create mlen in
+      Cstruct.blit_from_string msg 0 a 0 mlen;
+      let rec loop = function
+        | 0 -> Lwt.return_unit
+        | n -> write_and_check flow a >>= fun () -> loop (n-1)
+      in
+      loop (amt / mlen) >>= fun () ->
+      let a = Cstruct.sub a 0 (amt - (mlen * (amt/mlen))) in
+      write_and_check flow a >>= fun () ->
+      V.Stackv6.TCP.close flow
+    in
+    Logs.info (fun f -> f  "Iperf client: Attempting connection.");
+    tcp_connect (V.Stackv6.tcp s) (dest_ip, dport) >>= fun flow ->
+    iperftx flow >>= fun () ->
+    Logs.debug (fun f -> f  "Iperf client: Done.");
+    Lwt.return_unit
+
+  let print_data st ts_now =
+    let server = Int64.sub ts_now st.start_time in
+    let rate_in_mbps =
+        let t_in_s = Int64.(to_float (sub ts_now st.last_time)) /. 1_000_000_000. in
+        (Int64.to_float st.bin_bytes) /. t_in_s /. 125000.
+    in
+    let live_words = Gc.((stat()).live_words) in
+    Logs.info (fun f -> f  "Iperf server: t = %.0Lu, avg_rate = %0.2f MBits/s, totbytes = %Ld, \
+                             live_words = %d" server rate_in_mbps st.bytes live_words);
+    st.last_time <- ts_now;
+    st.bin_bytes <- 0L;
+    st.bin_packets <- 0L;
+    Lwt.return_unit
+
+  let iperf _s server_done_u flow =
+    (* debug is too much for us here *)
+    Logs.set_level ~all:true (Some Logs.Info);
+    Logs.info (fun f -> f  "Iperf server: Received connection.");
+    let t0 = Clock.elapsed_ns () in
+    let st = {
+      bytes=0L; packets=0L; bin_bytes=0L; bin_packets=0L; start_time = t0;
+      last_time = t0
+    } in
+    let rec iperf_h flow =
+      V.Stackv6.TCP.read flow >|= Rresult.R.get_ok >>= function
+      | `Eof ->
+        let ts_now = Clock.elapsed_ns () in
+        st.bin_bytes <- st.bytes;
+        st.bin_packets <- st.packets;
+        st.last_time <- st.start_time;
+        print_data st ts_now >>= fun () ->
+        V.Stackv6.TCP.close flow >>= fun () ->
+        Logs.info (fun f -> f  "Iperf server: Done - closed connection.");
+        Lwt.return_unit
+      | `Data data ->
+        begin
+          let l = Cstruct.len data in
+          st.bytes <- (Int64.add st.bytes (Int64.of_int l));
+          st.packets <- (Int64.add st.packets 1L);
+          st.bin_bytes <- (Int64.add st.bin_bytes (Int64.of_int l));
+          st.bin_packets <- (Int64.add st.bin_packets 1L);
+          let ts_now = Clock.elapsed_ns () in
+          (if (Int64.sub ts_now st.last_time >= 1_000_000_000L) then
+             print_data st ts_now
+           else
+             Lwt.return_unit) >>= fun () ->
+          iperf_h flow
+        end
+    in
+    iperf_h flow >>= fun () ->
+    Lwt.wakeup server_done_u ();
+    Lwt.return_unit
+
+  let tcp_iperf ~server ~client amt timeout () =
+    let port = 5001 in
+
+    let server_ready, server_ready_u = Lwt.wait () in
+    let server_done, server_done_u = Lwt.wait () in
+    let server_s, client_s = server, client in
+
+    let ip_of s = V.Stackv6.IP.get_ip (V.Stackv6.ip s) |> List.hd in
+
+    Lwt.pick [
+      (Lwt_unix.sleep timeout >>= fun () -> (* timeout *)
+       failf "iperf test timed out after %f seconds" timeout);
+
+      (server_ready >>= fun () ->
+       Lwt_unix.sleep 0.1 >>= fun () -> (* Give server 0.1 s to call listen *)
+       Logs.info (fun f -> f  "I am client with IP %a, trying to connect to server @ %a:%d"
+         Ipaddr.V6.pp (ip_of client_s) Ipaddr.V6.pp (ip_of server_s) port);
+       Lwt.async (fun () -> V.Stackv6.listen client_s);
+       iperfclient client_s amt (ip_of server) port);
+
+      (Logs.info (fun f -> f  "I am server with IP %a, expecting connections on port %d"
+         Ipaddr.V6.pp (V.Stackv6.IP.get_ip (V.Stackv6.ip server_s) |> List.hd)
+         port);
+       V.Stackv6.listen_tcp server_s ~port (iperf server_s server_done_u);
+       Lwt.wakeup server_ready_u ();
+       V.Stackv6.listen server_s) ] >>= fun () ->
+
+    Logs.info (fun f -> f  "Waiting for server_done...");
+    server_done >>= fun () ->
+    Lwt.return_unit (* exit cleanly *)
+end
+
+let test_tcp_iperf_ipv6_two_stacks_basic amt timeout () =
+  let module Test = Test_iperf_ipv6 (Vnetif_backends.Basic) in
+  Test.default_network () >>= fun { backend; Test.client; Test.server } ->
+  Test.V.record_pcap backend
+    (Printf.sprintf "tcp_iperf_ipv6_two_stacks_basic_%d.pcap" amt)
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let test_tcp_iperf_ipv6_two_stacks_mtu amt timeout () =
+  let mtu = 1500 in
+  let module Test = Test_iperf_ipv6 (Vnetif_backends.Frame_size_enforced) in
+  let backend = Vnetif_backends.Frame_size_enforced.create () in
+  Vnetif_backends.Frame_size_enforced.set_max_ip_mtu backend mtu;
+  Test.default_network ?mtu:(Some mtu) ?backend:(Some backend) () >>= fun { backend; Test.client; Test.server } ->
+  Test.V.record_pcap backend
+    (Printf.sprintf "tcp_iperf_ipv6_two_stacks_mtu_%d.pcap" amt)
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let test_tcp_iperf_ipv6_two_stacks_trailing_bytes amt timeout () =
+  let module Test = Test_iperf_ipv6 (Vnetif_backends.Trailing_bytes) in
+  Test.default_network () >>= fun { backend; Test.client; Test.server } ->
+  Test.V.record_pcap backend
+    (Printf.sprintf "tcp_iperf_ipv6_two_stacks_trailing_bytes_%d.pcap" amt)
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let test_tcp_iperf_ipv6_two_stacks_uniform_packet_loss amt timeout () =
+  let module Test = Test_iperf_ipv6 (Vnetif_backends.Uniform_packet_loss) in
+  Test.default_network () >>= fun { backend; Test.client; Test.server } ->
+  Test.V.record_pcap backend
+    (Printf.sprintf "tcp_iperf_ipv6_two_stacks_uniform_packet_loss_%d.pcap" amt)
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let test_tcp_iperf_ipv6_two_stacks_uniform_packet_loss_no_payload amt timeout () =
+  let module Test = Test_iperf_ipv6 (Vnetif_backends.Uniform_no_payload_packet_loss) in
+  Test.default_network () >>= fun { backend; Test.client; Test.server } ->
+  Test.V.record_pcap backend
+    (Printf.sprintf "tcp_iperf_ipv6_two_stacks_uniform_packet_loss_no_payload_%d.pcap" amt)
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let test_tcp_iperf_ipv6_two_stacks_drop_1sec_after_1mb amt timeout () =
+  let module Test = Test_iperf_ipv6 (Vnetif_backends.Drop_1_second_after_1_megabyte) in
+  Test.default_network () >>= fun { backend; Test.client; Test.server } ->
+  Test.V.record_pcap backend
+    "tcp_iperf_ipv6_two_stacks_drop_1sec_after_1mb.pcap"
+    (Test.tcp_iperf ~server ~client amt timeout)
+
+let amt_quick = 100_000
+let amt_slow  = amt_quick * 1000
+
+let suite = [
+
+  "iperf with two stacks, basic tests", `Quick,
+  test_tcp_iperf_ipv6_two_stacks_basic amt_quick 120.0;
+
+  "iperf with two stacks, over an MTU-enforcing backend", `Quick,
+  test_tcp_iperf_ipv6_two_stacks_mtu amt_quick 120.0;
+
+  "iperf with two stacks, testing trailing_bytes", `Quick,
+  test_tcp_iperf_ipv6_two_stacks_trailing_bytes amt_quick 120.0;
+
+  "iperf with two stacks and uniform packet loss", `Quick,
+  test_tcp_iperf_ipv6_two_stacks_uniform_packet_loss amt_quick 120.0;
+
+  "iperf with two stacks and uniform packet loss of packets with no payload", `Quick,
+  test_tcp_iperf_ipv6_two_stacks_uniform_packet_loss_no_payload amt_quick 120.0;
+
+  "iperf with two stacks and uniform packet loss of packets with no payload, longer", `Slow,
+  test_tcp_iperf_ipv6_two_stacks_uniform_packet_loss_no_payload amt_slow 240.0;
+
+  "iperf with two stacks, basic tests, longer", `Slow,
+  test_tcp_iperf_ipv6_two_stacks_basic amt_slow 240.0;
+
+  "iperf with two stacks and uniform packet loss, longer", `Slow,
+  test_tcp_iperf_ipv6_two_stacks_uniform_packet_loss amt_slow 240.0;
+
+  "iperf with two stacks drop 1 sec after 1 mb", `Quick,
+  test_tcp_iperf_ipv6_two_stacks_drop_1sec_after_1mb amt_quick 120.0;
+
+]

--- a/test/test_tcp_options.ml
+++ b/test/test_tcp_options.ml
@@ -63,8 +63,8 @@ let test_unmarshal_simple_options () =
 
 let test_unmarshal_stops_at_eof () =
   let buf = Cstruct.create 14 in
-  let ts1 = (Int32.of_int 0xabad1dea) in
-  let ts2 = (Int32.of_int 0xc0ffee33) in
+  let ts1 = 0xabad1deal in
+  let ts2 = 0xc0ffee33l in
   Cstruct.memset buf 0;
   Cstruct.set_uint8 buf 0 4; (* sack_ok *)
   Cstruct.set_uint8 buf 1 2; (* length of two *)


### PR DESCRIPTION
This adds support for configuring a V6 stack in tcpip_stack_direct and adds a TCPv6 connect test that succeeds. ~~It depends on unmerged changes in mirage-stack so shouldn't be merged yet (mirage-stack is pinned to my branch).~~

~~I had to disable the test that adds trailing bytes to the ethernet frames, as this results in a lot of packets being dropped due to checksum errors in our stack (checksum in pcap is fine). This seems to indicate that the implementation calculates the checksum of the full buffer - not just the IP packet length, but I haven't investigated this further.~~ (fixed)

The stack will also queue packets without a source IP before the IPv6 address has been negotiated. These packets will be sent when the IP is available and confuse the other end. I've added a temporary fix to wait for the IPv6 address to be configured before the test starts.