### PR TITLE
Add cancelation on tcpip.stack-socket

### DIFF
--- a/src/stack-unix/tcpip_stack_socket.ml
+++ b/src/stack-unix/tcpip_stack_socket.ml
@@ -97,7 +97,7 @@ module V4 = struct
           in
           Lwt.catch loop (fun _-> Lwt.return_unit) >>= fun () -> Lwt_unix.close fd)
 
-  let listen t = t.switched_off >>= fun () -> Lwt.return_unit
+  let listen t = t.switched_off
 
   let connect udpv4 tcpv4 =
     Log.info (fun f -> f "IPv4 socket stack: connect");


### PR DESCRIPTION
This PR wants to fix an issue about cancelation of listening socket. You can see the error on this CI output:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/661b80c8d56556cd711fb2e8f7a1c0edae56bf15

I would like to have a review to incorporate it into `6.1.0` and it should close the issue #437. (/cc @talex5 & @hannesm)