### PR TITLE
Make freestanding compilation possible w/o opam

### DIFF
--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -1,5 +1,5 @@
 ifneq (, $(shell command -v opam))
-	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
+	PKG_CONFIG_PATH ?= $(shell opam var prefix)/lib/pkgconfig
 endif
 
 EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)

--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -1,4 +1,6 @@
-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+ifneq (, $(shell command -v opam))
+	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
+endif
 
 EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)
 


### PR DESCRIPTION
If we miss opam we just invoke pkg-config with PKG_CONFIG_PATH from the
environment (if any). Also don't override a manually passed
PKG_CONFIG_PATH even if we have opam.

Patch taken from <https://github.com/NixOS/nixpkgs/pull/117948>.