### PR TITLE
Restore compatibility with Alcotest.1.4.0

### DIFF
--- a/test/common.ml
+++ b/test/common.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-let failf fmt = Fmt.kstrf Alcotest.fail fmt
+let failf fmt = Fmt.kstrf (fun s -> Alcotest.fail s) fmt
 
 let or_error name fn t =
   fn t >>= function

--- a/test/test_tcp_options.ml
+++ b/test/test_tcp_options.ml
@@ -3,9 +3,7 @@ open Common
 let check = Alcotest.(check @@ result (list options) string)
 
 let errors ?(check_msg = false) exp = function
-  | Ok opt ->
-    Fmt.kstrf Alcotest.fail "Ok %a when Error %s expected"
-      Tcp.Options.pps opt exp
+  | Ok opt -> failf "Ok %a when Error %s expected" Tcp.Options.pps opt exp
   | Error p -> if check_msg then
       Alcotest.(check string)
         "Error didn't give the expected error message" exp p


### PR DESCRIPTION
The Alcotest 1.4.0 release adds optional arguments to Alcotest.fail.  Eta-expansion is necessary to use this function with the continuation printers.