### PR TITLE
stack-unix: convert dual socket to v4 or v6 src IP

### DIFF
--- a/src/stack-unix/tcpip_stack_socket.ml
+++ b/src/stack-unix/tcpip_stack_socket.ml
@@ -235,6 +235,11 @@ module V4V6 = struct
                         (match sa with
                          | Lwt_unix.ADDR_INET (addr, src_port) ->
                            let src = Ipaddr_unix.of_inet_addr addr in
+                           let src =
+                             match Ipaddr.to_v4 src with
+                             | None -> src
+                             | Some v4 -> Ipaddr.V4 v4
+                           in
                            let dst = Ipaddr.(V6 V6.unspecified) in (* TODO *)
                            callback ~src ~dst ~src_port buf
                          | _ -> Lwt.return_unit))

--- a/src/stack-unix/tcpv4v6_socket.ml
+++ b/src/stack-unix/tcpv4v6_socket.ml
@@ -55,7 +55,13 @@ let dst fd =
   match Lwt_unix.getpeername fd with
   | Unix.ADDR_UNIX _ ->
     raise (Failure "unexpected: got a unix instead of tcp sock")
-  | Unix.ADDR_INET (ia,port) -> Ipaddr_unix.of_inet_addr ia,port
+  | Unix.ADDR_INET (ia,port) ->
+    let ip = Ipaddr_unix.of_inet_addr ia in
+    let ip = match Ipaddr.to_v4 ip with
+      | None -> ip
+      | Some v4 -> Ipaddr.V4 v4
+    in
+    ip, port
 
 let create_connection ?keepalive t (dst,dst_port) =
   match


### PR DESCRIPTION
The UDP callback includes a source IP address as Ipaddr.t. For a dual stack using sockets, a PF_INET6 socket is used -- so the sockaddr originating from that socket will always be an IPv6 address.

The semantics in the direct stack is that if a IPv4 source sends data, an `Ipaddr.V4 _` is provided to the callback, if a IPv6 source sends data, an `Ipaddr.V6 _` is provided.

This commit adapts the same semantics to the socket stack -- if the retrieved sockaddr is representable as IPv4 address, this is used in the callback. The same is done for `dst` in the tcpv4v6 socket.