### PR TITLE
Adapt to mirage/mirage-protocols#28 changes:

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### v6.4.0 (2021-11-11)
+
+* Adapt to mirage-protocols 6.0.0 API (#457 @hannesm)
+* TCP and UDP now have a listen and unlisten function (fixes #452)
+* type ipinput (in TCP and UDP) and listener (in TCP) have been removed
+
 ### v6.3.0 (2021-10-25)
 
 * Use Cstruct.length instead of deprecated Cstruct.len (#454 @hannesm)

--- a/src/stack-direct/tcpip_stack_direct.mli
+++ b/src/stack-direct/tcpip_stack_direct.mli
@@ -14,15 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type direct_ipv4_input = src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> Cstruct.t -> unit Lwt.t
-
 module type UDPV4_DIRECT = Mirage_protocols.UDP
   with type ipaddr = Ipaddr.V4.t
-   and type ipinput = direct_ipv4_input
 
 module type TCPV4_DIRECT = Mirage_protocols.TCP
   with type ipaddr = Ipaddr.V4.t
-   and type ipinput = direct_ipv4_input
 
 module Make
     (Time     : Mirage_time.S)
@@ -48,15 +44,11 @@ module Make
       connections, they will be able to do so. *)
 end
 
-type direct_ipv6_input = src:Ipaddr.V6.t -> dst:Ipaddr.V6.t -> Cstruct.t -> unit Lwt.t
-
 module type UDPV6_DIRECT = Mirage_protocols.UDP
   with type ipaddr = Ipaddr.V6.t
-   and type ipinput = direct_ipv6_input
 
 module type TCPV6_DIRECT = Mirage_protocols.TCP
   with type ipaddr = Ipaddr.V6.t
-   and type ipinput = direct_ipv6_input
 
 module MakeV6
     (Time     : Mirage_time.S)
@@ -79,15 +71,11 @@ module MakeV6
       they will be able to do so. *)
 end
 
-type direct_ipv4v6_input = src:Ipaddr.t -> dst:Ipaddr.t -> Cstruct.t -> unit Lwt.t
-
 module type UDPV4V6_DIRECT = Mirage_protocols.UDP
   with type ipaddr = Ipaddr.t
-   and type ipinput = direct_ipv4v6_input
 
 module type TCPV4V6_DIRECT = Mirage_protocols.TCP
   with type ipaddr = Ipaddr.t
-   and type ipinput = direct_ipv4v6_input
 
 module IPV4V6 (Ipv4 : Mirage_protocols.IPV4) (Ipv6 : Mirage_protocols.IPV6) : sig
   include Mirage_protocols.IP with type ipaddr = Ipaddr.t

--- a/src/stack-unix/dune
+++ b/src/stack-unix/dune
@@ -15,7 +15,7 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols logs))
 
 (library
  (name udpv6_socket)
@@ -24,7 +24,7 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols logs))
 
 (library
  (name udpv4v6_socket)
@@ -33,7 +33,7 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols logs))
 
 (library
  (name tcp_socket_options)
@@ -56,7 +56,7 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols
-   tcp_socket_options))
+   tcp_socket_options logs))
 
 (library
  (name tcpv6_socket)
@@ -66,7 +66,7 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols
-   tcpv4_socket tcp_socket_options))
+   tcpv4_socket tcp_socket_options logs))
 
 (library
  (name tcpv4v6_socket)
@@ -76,7 +76,7 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols
-   tcpv4_socket tcp_socket_options))
+   tcpv4_socket tcp_socket_options logs))
 
 (library
  (name tcpip_stack_socket)

--- a/src/stack-unix/tcp_socket.ml
+++ b/src/stack-unix/tcp_socket.ml
@@ -11,6 +11,10 @@ let pp_write_error ppf = function
   | #Mirage_protocols.Tcp.write_error as e -> Mirage_protocols.Tcp.pp_write_error ppf e
   | `Exn e -> Fmt.exn ppf e
 
+let ignore_canceled = function
+  | Lwt.Canceled -> Lwt.return_unit
+  | exn -> raise exn
+
 let disconnect _ =
   return_unit
 
@@ -61,13 +65,4 @@ let close fd =
       | Unix.Unix_error (Unix.EBADF, _, _) -> Lwt.return_unit
       | e -> Lwt.fail e)
 
-type listener = {
-  process: Lwt_unix.file_descr -> unit Lwt.t;
-  keepalive: Mirage_protocols.Keepalive.t option;
-}
-
-(* FIXME: how does this work at all ?? *)
-let input _t ~listeners:_ =
-  (* TODO terminate when signalled by disconnect *)
-  let t, _ = Lwt.task () in
-  t
+let input _t ~src:_ ~dst:_ _buf = Lwt.return_unit

--- a/src/stack-unix/tcpip_stack_socket.ml
+++ b/src/stack-unix/tcpip_stack_socket.ml
@@ -19,12 +19,6 @@ open Lwt.Infix
 let src = Logs.Src.create "tcpip-stack-socket" ~doc:"Platform's native TCP/IP stack"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let ignore_canceled = function
-  | Lwt.Canceled -> Lwt.return_unit
-  | exn -> raise exn
-
-let safe_close = Tcp_socket.close
-
 module V4 = struct
   module TCPV4 = Tcpv4_socket
   module UDPV4 = Udpv4_socket
@@ -35,98 +29,28 @@ module V4 = struct
     tcpv4 : TCPV4.t;
     stop : unit Lwt.u;
     switched_off : unit Lwt.t;
-    mutable active_fds : Lwt_unix.file_descr list;
   }
 
   let udpv4 { udpv4; _ } = udpv4
   let tcpv4 { tcpv4; _ } = tcpv4
   let ipv4 _ = ()
 
-  let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p
-
   let listen_udpv4 t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      (* FIXME: we should not ignore the result *)
-      Lwt.async (fun () ->
-          UDPV4.get_udpv4_listening_fd t.udpv4 port >>= fun (_, fd) ->
-          let buf = Cstruct.create 4096 in
-          let rec loop () =
-            if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
-            Lwt.catch (fun () ->
-                Lwt_cstruct.recvfrom fd buf [] >>= fun (len, sa) ->
-                let buf = Cstruct.sub buf 0 len in
-                (match sa with
-                 | Lwt_unix.ADDR_INET (addr, src_port) ->
-                   let src = Ipaddr_unix.V4.of_inet_addr_exn addr in
-                   let dst = Ipaddr.V4.any in (* TODO *)
-                   callback ~src ~dst ~src_port buf
-                 | _ -> Lwt.return_unit) >|= fun () ->
-                 `Continue)
-             (function
-               | Unix.Unix_error (Unix.EBADF, _, _) ->
-                 Log.warn (fun m -> m "error bad file descriptor in accept") ;
-                 Lwt.return `Stop
-               | exn ->
-                 Log.warn (fun m -> m "exception %s in recvfrom" (Printexc.to_string exn)) ;
-                 Lwt.return `Continue) >>= function
-            | `Continue -> loop ()
-            | `Stop -> Lwt.return_unit
-          in
-          Lwt.catch loop ignore_canceled >>= fun () ->
-          safe_close fd)
+    UDPV4.listen t.udpv4 ~port callback
 
   let listen_tcpv4 ?keepalive t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      let fd = Lwt_unix.(socket PF_INET SOCK_STREAM 0) in
-      t.active_fds <- fd :: t.active_fds;
-      Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
-      Unix.bind (Lwt_unix.unix_file_descr fd) (Unix.ADDR_INET (t.udpv4.interface, port));
-      Lwt_unix.listen fd 10;
-      (* FIXME: we should not ignore the result *)
-      Lwt.async (fun () ->
-          (* TODO cancellation *)
-          let rec loop () =
-            if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
-            Lwt.catch (fun () ->
-                Lwt_unix.accept fd >|= fun (afd, _) ->
-                t.active_fds <- afd :: t.active_fds;
-                (match keepalive with
-                 | None -> ()
-                 | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
-                   Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
-                Lwt.async
-                  (fun () ->
-                     Lwt.catch
-                       (fun () -> callback afd)
-                       (fun exn ->
-                          Log.warn (fun m -> m "error %s in callback" (Printexc.to_string exn)) ;
-                          safe_close afd));
-                `Continue)
-              (function
-               | Unix.Unix_error (Unix.EBADF, _, _) ->
-                 Log.warn (fun m -> m "error bad file descriptor in accept") ;
-                 Lwt.return `Stop
-               | exn ->
-                 Log.warn (fun m -> m "error %s in accept" (Printexc.to_string exn)) ;
-                 Lwt.return `Continue) >>= function
-            | `Continue -> loop ()
-            | `Stop -> Lwt.return_unit
-          in
-          Lwt.catch loop ignore_canceled >>= fun () -> safe_close fd)
+    TCPV4.listen t.tcpv4 ~port ?keepalive callback
 
   let listen t = t.switched_off
 
   let connect udpv4 tcpv4 =
     Log.info (fun f -> f "IPv4 socket stack: connect");
     let switched_off, stop = Lwt.wait () in
-    Lwt.return { tcpv4; udpv4; stop; switched_off; active_fds = []; }
+    TCPV4.set_switched_off tcpv4 switched_off;
+    UDPV4.set_switched_off udpv4 switched_off;
+    Lwt.return { tcpv4; udpv4; stop; switched_off }
 
   let disconnect t =
-    Lwt_list.iter_p safe_close t.active_fds >>= fun () ->
     TCPV4.disconnect t.tcpv4 >>= fun () ->
     UDPV4.disconnect t.udpv4 >|= fun () ->
     Lwt.wakeup_later t.stop ()
@@ -142,98 +66,28 @@ module V6 = struct
     tcp : TCP.t;
     stop : unit Lwt.u;
     switched_off : unit Lwt.t;
-    mutable active_fds : Lwt_unix.file_descr list;
   }
 
   let udp { udp; _ } = udp
   let tcp { tcp; _ } = tcp
   let ip _ = ()
 
-  let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p
-
   let listen_udp t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      (* FIXME: we should not ignore the result *)
-      Lwt.async (fun () ->
-          UDP.get_udpv6_listening_fd t.udp port >>= fun (_, fd) ->
-          let buf = Cstruct.create 4096 in
-          let rec loop () =
-            if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
-            Lwt.catch (fun () ->
-                Lwt_cstruct.recvfrom fd buf [] >>= fun (len, sa) ->
-                let buf = Cstruct.sub buf 0 len in
-                (match sa with
-                 | Lwt_unix.ADDR_INET (addr, src_port) ->
-                   let src = Ipaddr_unix.V6.of_inet_addr_exn addr in
-                   let dst = Ipaddr.V6.unspecified in (* TODO *)
-                   callback ~src ~dst ~src_port buf
-                 | _ -> Lwt.return_unit) >|= fun () ->
-                 `Continue)
-             (function
-               | Unix.Unix_error (Unix.EBADF, _, _) ->
-                 Log.warn (fun m -> m "error bad file descriptor in accept") ;
-                 Lwt.return `Stop
-               | exn ->
-                 Log.warn (fun m -> m "exception %s in recvfrom" (Printexc.to_string exn)) ;
-                 Lwt.return `Continue) >>= function
-            | `Continue -> loop ()
-            | `Stop -> Lwt.return_unit
-          in
-          Lwt.catch loop ignore_canceled >>= fun () -> safe_close fd)
+    UDP.listen t.udp ~port callback
 
   let listen_tcp ?keepalive t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      let fd = Lwt_unix.(socket PF_INET6 SOCK_STREAM 0) in
-      t.active_fds <- fd :: t.active_fds;
-      Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
-      Lwt_unix.(setsockopt fd IPV6_ONLY true);
-      Unix.bind (Lwt_unix.unix_file_descr fd) (Lwt_unix.ADDR_INET (t.udp.interface, port));
-      Lwt_unix.listen fd 10;
-      (* FIXME: we should not ignore the result *)
-      Lwt.async (fun () ->
-          (* TODO cancellation *)
-          let rec loop () =
-            if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
-            Lwt.catch (fun () ->
-                Lwt_unix.accept fd >|= fun (afd, _) ->
-                t.active_fds <- afd :: t.active_fds;
-                (match keepalive with
-                 | None -> ()
-                 | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
-                   Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
-                Lwt.async
-                  (fun () ->
-                     Lwt.catch
-                       (fun () -> callback afd)
-                       (fun exn ->
-                          Log.warn (fun m -> m "error %s in callback" (Printexc.to_string exn)) ;
-                          safe_close afd));
-                `Continue)
-              (function
-               | Unix.Unix_error (Unix.EBADF, _, _) ->
-                 Log.warn (fun m -> m "error bad file descriptor in accept") ;
-                 Lwt.return `Stop
-               | exn ->
-                 Log.warn (fun m -> m "error %s in accept" (Printexc.to_string exn)) ;
-                 Lwt.return `Continue) >>= function
-            | `Continue -> loop ()
-            | `Stop -> Lwt.return_unit
-          in
-          Lwt.catch loop ignore_canceled >>= fun () -> safe_close fd)
+    TCP.listen t.tcp ~port ?keepalive callback
 
   let listen t = t.switched_off
 
   let connect udp tcp =
     Log.info (fun f -> f "IPv6 socket stack: connect");
     let switched_off, stop = Lwt.wait () in
-    Lwt.return { tcp; udp; stop; switched_off; active_fds = []; }
+    UDP.set_switched_off udp switched_off;
+    TCP.set_switched_off tcp switched_off;
+    Lwt.return { tcp; udp; stop; switched_off }
 
   let disconnect t =
-    Lwt_list.iter_p safe_close t.active_fds >>= fun () ->
     TCP.disconnect t.tcp >>= fun () ->
     UDP.disconnect t.udp >|= fun () ->
     Lwt.wakeup_later t.stop ()
@@ -249,128 +103,28 @@ module V4V6 = struct
     tcp : TCP.t;
     stop : unit Lwt.u;
     switched_off : unit Lwt.t;
-    mutable active_fds : Lwt_unix.file_descr list;
   }
 
   let udp { udp; _ } = udp
   let tcp { tcp; _ } = tcp
   let ip _ = ()
 
-  let err_invalid_port p = Printf.sprintf "invalid port number (%d)" p
-
   let listen_udp t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      (* FIXME: we should not ignore the result *)
-      Lwt.async (fun () ->
-          UDP.get_udpv4v6_listening_fd t.udp port >|= fun (_, fds) ->
-          t.active_fds <- fds @ t.active_fds;
-          List.iter (fun fd ->
-              Lwt.async (fun () ->
-                  let buf = Cstruct.create 4096 in
-                  let rec loop () =
-                    if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
-                    Lwt.catch (fun () ->
-                        Lwt_cstruct.recvfrom fd buf [] >>= fun (len, sa) ->
-                        let buf = Cstruct.sub buf 0 len in
-                        (match sa with
-                         | Lwt_unix.ADDR_INET (addr, src_port) ->
-                           let src = Ipaddr_unix.of_inet_addr addr in
-                           let src =
-                             match Ipaddr.to_v4 src with
-                             | None -> src
-                             | Some v4 -> Ipaddr.V4 v4
-                           in
-                           let dst = Ipaddr.(V6 V6.unspecified) in (* TODO *)
-                           callback ~src ~dst ~src_port buf
-                         | _ -> Lwt.return_unit) >|= fun () ->
-                        `Continue)
-                      (function
-                       | Unix.Unix_error (Unix.EBADF, _, _) ->
-                         Log.warn (fun m -> m "error bad file descriptor in accept") ;
-                         Lwt.return `Stop
-                       | exn ->
-                         Log.warn (fun m -> m "exception %s in recvfrom" (Printexc.to_string exn)) ;
-                         Lwt.return `Continue) >>= function
-                    | `Continue -> loop ()
-                    | `Stop -> Lwt.return_unit
-                  in
-                  Lwt.catch loop ignore_canceled >>= fun () -> safe_close fd)) fds)
+    UDP.listen t.udp ~port callback
 
   let listen_tcp ?keepalive t ~port callback =
-    if port < 0 || port > 65535 then
-      raise (Invalid_argument (err_invalid_port port))
-    else
-      let fds =
-        match t.udp.interface with
-        | `Any ->
-          let fd = Lwt_unix.(socket PF_INET6 SOCK_STREAM 0) in
-          Lwt_unix.(setsockopt fd SO_REUSEADDR true);
-          Lwt_unix.(setsockopt fd IPV6_ONLY false);
-          [ (fd, Lwt_unix.ADDR_INET (UDP.any_v6, port)) ]
-        | `Ip (v4, v6) ->
-          let fd = Lwt_unix.(socket PF_INET SOCK_STREAM 0) in
-          Lwt_unix.(setsockopt fd SO_REUSEADDR true);
-          let fd' = Lwt_unix.(socket PF_INET6 SOCK_STREAM 0) in
-          Lwt_unix.(setsockopt fd' SO_REUSEADDR true);
-          Lwt_unix.(setsockopt fd' IPV6_ONLY true);
-          [ (fd, Lwt_unix.ADDR_INET (v4, port)) ; (fd', Lwt_unix.ADDR_INET (v6, port)) ]
-        | `V4_only ip ->
-          let fd = Lwt_unix.(socket PF_INET SOCK_STREAM 0) in
-          Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
-          [ (fd, Lwt_unix.ADDR_INET (ip, port)) ]
-        | `V6_only ip ->
-          let fd = Lwt_unix.(socket PF_INET6 SOCK_STREAM 0) in
-          Lwt_unix.(setsockopt fd SO_REUSEADDR true);
-          Lwt_unix.(setsockopt fd IPV6_ONLY true);
-          [ (fd, Lwt_unix.ADDR_INET (ip, port)) ]
-      in
-      t.active_fds <- List.map fst fds @ t.active_fds;
-      List.iter (fun (fd, addr) ->
-          Unix.bind (Lwt_unix.unix_file_descr fd) addr;
-          Lwt_unix.listen fd 10;
-          (* FIXME: we should not ignore the result *)
-          Lwt.async (fun () ->
-              (* TODO cancellation *)
-              let rec loop () =
-                if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
-                Lwt.catch (fun () ->
-                    Lwt_unix.accept fd >|= fun (afd, _) ->
-                    t.active_fds <- afd :: t.active_fds;
-                    (match keepalive with
-                     | None -> ()
-                     | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
-                       Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
-                    Lwt.async
-                      (fun () ->
-                         Lwt.catch
-                           (fun () -> callback afd)
-                           (fun exn ->
-                              Log.warn (fun m -> m "error %s in callback" (Printexc.to_string exn)) ;
-                              safe_close afd));
-                    `Continue)
-                  (function
-                   | Unix.Unix_error (Unix.EBADF, _, _) ->
-                     Log.warn (fun m -> m "error bad file descriptor in accept") ;
-                     Lwt.return `Stop
-                   | exn ->
-                     Log.warn (fun m -> m "error %s in accept" (Printexc.to_string exn)) ;
-                     Lwt.return `Continue) >>= function
-                  | `Continue -> loop ()
-                  | `Stop -> Lwt.return_unit
-              in
-              Lwt.catch loop ignore_canceled >>= fun () -> safe_close fd)) fds
+    TCP.listen t.tcp ~port ?keepalive callback
 
   let listen t = t.switched_off
 
   let connect udp tcp =
     Log.info (fun f -> f "Dual IPv4 and IPv6 socket stack: connect");
     let switched_off, stop = Lwt.wait () in
-    Lwt.return { tcp; udp; stop; switched_off; active_fds = [] }
+    UDP.set_switched_off udp switched_off;
+    TCP.set_switched_off tcp switched_off;
+    Lwt.return { tcp; udp; stop; switched_off }
 
   let disconnect t =
-    Lwt_list.iter_p safe_close t.active_fds >>= fun () ->
     TCP.disconnect t.tcp >>= fun () ->
     UDP.disconnect t.udp >|= fun () ->
     Lwt.wakeup_later t.stop ()

--- a/src/stack-unix/tcpv4_socket.ml
+++ b/src/stack-unix/tcpv4_socket.ml
@@ -14,15 +14,19 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+let src = Logs.Src.create "tcpv4-socket" ~doc:"TCP socket v4 (platform native)"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 open Lwt.Infix
 
 type ipaddr = Ipaddr.V4.t
 type flow = Lwt_unix.file_descr
-type ipinput = unit Lwt.t
 
 type t = {
   interface: Unix.inet_addr;    (* source ip to bind to *)
   mutable active_connections : Lwt_unix.file_descr list;
+  listen_sockets : (int, Lwt_unix.file_descr) Hashtbl.t;
+  mutable switched_off : unit Lwt.t;
 }
 
 include Tcp_socket
@@ -31,10 +35,17 @@ let connect addr =
   let t = {
     interface = Ipaddr_unix.V4.to_inet_addr (Ipaddr.V4.Prefix.address addr);
     active_connections = [];
+    listen_sockets = Hashtbl.create 7;
+    switched_off = Lwt.return_unit;
   } in
   Lwt.return t
 
-let disconnect t = Lwt_list.iter_p close t.active_connections
+let set_switched_off t switched_off = t.switched_off <- switched_off
+
+let disconnect t =
+  Lwt_list.iter_p close t.active_connections >>= fun () ->
+  Lwt_list.iter_p close
+    (Hashtbl.fold (fun _ fd acc -> fd :: acc) t.listen_sockets [])
 
 let dst fd =
   match Lwt_unix.getpeername fd with
@@ -62,3 +73,51 @@ let create_connection ?keepalive t (dst,dst_port) =
     (fun exn ->
        close fd >|= fun () ->
        Error (`Exn exn))
+
+let unlisten t ~port =
+  match Hashtbl.find_opt t.listen_sockets port with
+  | None -> ()
+  | Some fd ->
+    Hashtbl.remove t.listen_sockets port;
+    try Unix.close (Lwt_unix.unix_file_descr fd) with _ -> ()
+
+let listen t ~port ?keepalive callback =
+    if port < 0 || port > 65535 then
+      raise (Invalid_argument (Printf.sprintf "invalid port number (%d)" port));
+    unlisten t ~port;
+    let fd = Lwt_unix.(socket PF_INET SOCK_STREAM 0) in
+    Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
+    Unix.bind (Lwt_unix.unix_file_descr fd) (Unix.ADDR_INET (t.interface, port));
+    Hashtbl.replace t.listen_sockets port fd;
+    Lwt_unix.listen fd 10;
+    (* FIXME: we should not ignore the result *)
+    Lwt.async (fun () ->
+        (* TODO cancellation *)
+        let rec loop () =
+          if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
+          Lwt.catch (fun () ->
+              Lwt_unix.accept fd >|= fun (afd, _) ->
+              t.active_connections <- afd :: t.active_connections;
+              (match keepalive with
+               | None -> ()
+               | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+                 Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
+              Lwt.async
+                (fun () ->
+                   Lwt.catch
+                     (fun () -> callback afd)
+                     (fun exn ->
+                        Log.warn (fun m -> m "error %s in callback" (Printexc.to_string exn)) ;
+                        close afd));
+              `Continue)
+            (function
+              | Unix.Unix_error (Unix.EBADF, _, _) ->
+                Log.warn (fun m -> m "error bad file descriptor in accept") ;
+                Lwt.return `Stop
+              | exn ->
+                Log.warn (fun m -> m "error %s in accept" (Printexc.to_string exn)) ;
+                Lwt.return `Continue) >>= function
+          | `Continue -> loop ()
+          | `Stop -> Lwt.return_unit
+        in
+        Lwt.catch loop ignore_canceled >>= fun () -> close fd)

--- a/src/stack-unix/tcpv4_socket.mli
+++ b/src/stack-unix/tcpv4_socket.mli
@@ -16,7 +16,6 @@
 
 include Mirage_protocols.TCP
   with type ipaddr = Ipaddr.V4.t
-   and type ipinput = unit Lwt.t
    and type flow = Lwt_unix.file_descr
    and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
    and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
@@ -24,3 +23,5 @@ include Mirage_protocols.TCP
 val connect : Ipaddr.V4.Prefix.t -> t Lwt.t
 
 val disconnect : t -> unit Lwt.t
+
+val set_switched_off : t -> unit Lwt.t -> unit

--- a/src/stack-unix/tcpv4v6_socket.mli
+++ b/src/stack-unix/tcpv4v6_socket.mli
@@ -17,9 +17,10 @@
 
 include Mirage_protocols.TCP
   with type ipaddr = Ipaddr.t
-   and type ipinput = unit Lwt.t
    and type flow = Lwt_unix.file_descr
    and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
    and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
 
 val connect : ipv4_only:bool -> ipv6_only:bool -> Ipaddr.V4.Prefix.t -> Ipaddr.V6.Prefix.t option -> t Lwt.t
+
+val set_switched_off : t -> unit Lwt.t -> unit

--- a/src/stack-unix/tcpv6_socket.mli
+++ b/src/stack-unix/tcpv6_socket.mli
@@ -17,7 +17,6 @@
 
 include Mirage_protocols.TCP
   with type ipaddr = Ipaddr.V6.t
-   and type ipinput = unit Lwt.t
    and type flow = Lwt_unix.file_descr
    and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
    and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
@@ -25,3 +24,5 @@ include Mirage_protocols.TCP
 val connect : Ipaddr.V6.Prefix.t option -> t Lwt.t
 
 val disconnect : t -> unit Lwt.t
+
+val set_switched_off : t -> unit Lwt.t -> unit

--- a/src/stack-unix/udpv4_socket.ml
+++ b/src/stack-unix/udpv4_socket.ml
@@ -14,18 +14,27 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+let src = Logs.Src.create "udpv4-socket" ~doc:"UDP socket v4 (platform native)"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 open Lwt.Infix
 
 type ipaddr = Ipaddr.V4.t
-type ipinput = unit Lwt.t
 type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lwt.t
 
 type t = {
   interface: Unix.inet_addr; (* source ip to bind to *)
   listen_fds: ((Unix.inet_addr * int),Lwt_unix.file_descr) Hashtbl.t; (* UDPv4 fds bound to a particular source ip/port *)
+  mutable switched_off: unit Lwt.t;
 }
 
-let get_udpv4_listening_fd ?(preserve = true) {listen_fds;interface} port =
+let set_switched_off t switched_off = t.switched_off <- switched_off
+
+let ignore_canceled = function
+  | Lwt.Canceled -> Lwt.return_unit
+  | exn -> raise exn
+
+let get_udpv4_listening_fd ?(preserve = true) {listen_fds;interface;_} port =
   try
     Lwt.return (false, Hashtbl.find listen_fds (interface,port))
   with Not_found ->
@@ -50,14 +59,14 @@ let connect ip =
   let t =
     let listen_fds = Hashtbl.create 7 in
     let interface = Ipaddr_unix.V4.to_inet_addr (Ipaddr.V4.Prefix.address ip) in
-    { interface; listen_fds }
+    { interface; listen_fds; switched_off = Lwt.return_unit }
   in
   Lwt.return t
 
 let disconnect t =
   Hashtbl.fold (fun _ fd r -> r >>= fun () -> close fd) t.listen_fds Lwt.return_unit
 
-let input ~listeners:_ _ = Lwt.return_unit
+let input _t ~src:_ ~dst:_ _buf = Lwt.return_unit
 
 let write ?src:_ ?src_port ?ttl:_ttl ~dst ~dst_port t buf =
   let open Lwt_unix in
@@ -75,3 +84,43 @@ let write ?src:_ ?src_port ?ttl:_ttl ~dst ~dst_port t buf =
   write_to_fd fd buf >>= fun r ->
   (if created then close fd else Lwt.return_unit) >|= fun () ->
   r
+
+let unlisten t ~port =
+  try
+    let fd = Hashtbl.find t.listen_fds (t.interface, port) in
+    Hashtbl.remove t.listen_fds (t.interface, port);
+    Unix.close (Lwt_unix.unix_file_descr fd)
+  with _ -> ()
+
+let listen t ~port callback =
+  if port < 0 || port > 65535 then
+    raise (Invalid_argument (Printf.sprintf "invalid port number (%d)" port));
+  unlisten t ~port;
+  (* FIXME: we should not ignore the result *)
+  Lwt.async (fun () ->
+      get_udpv4_listening_fd t port >>= fun (_, fd) ->
+      let buf = Cstruct.create 4096 in
+      let rec loop () =
+        if not (Lwt.is_sleeping t.switched_off) then raise Lwt.Canceled ;
+        Lwt.catch (fun () ->
+            Lwt_cstruct.recvfrom fd buf [] >>= fun (len, sa) ->
+            let buf = Cstruct.sub buf 0 len in
+            (match sa with
+             | Lwt_unix.ADDR_INET (addr, src_port) ->
+               let src = Ipaddr_unix.V4.of_inet_addr_exn addr in
+               let dst = Ipaddr.V4.any in (* TODO *)
+               callback ~src ~dst ~src_port buf
+             | _ -> Lwt.return_unit) >|= fun () ->
+            `Continue)
+          (function
+            | Unix.Unix_error (Unix.EBADF, _, _) ->
+              Log.warn (fun m -> m "error bad file descriptor in accept") ;
+              Lwt.return `Stop
+            | exn ->
+              Log.warn (fun m -> m "exception %s in recvfrom" (Printexc.to_string exn)) ;
+              Lwt.return `Continue) >>= function
+        | `Continue -> loop ()
+        | `Stop -> Lwt.return_unit
+      in
+      Lwt.catch loop ignore_canceled >>= fun () ->
+      close fd)

--- a/src/tcp/flow.mli
+++ b/src/tcp/flow.mli
@@ -20,6 +20,5 @@ module Make (IP:Mirage_protocols.IP)
             (R:Mirage_random.S) : sig
   include Mirage_protocols.TCP
     with type ipaddr = IP.ipaddr
-     and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
   val connect : IP.t -> t Lwt.t
 end

--- a/src/udp/udp.mli
+++ b/src/udp/udp.mli
@@ -18,6 +18,5 @@
 module Make (IP:Mirage_protocols.IP)(R:Mirage_random.S) : sig
   include Mirage_protocols.UDP
      with type ipaddr = IP.ipaddr
-     and type ipinput = src:IP.ipaddr -> dst:IP.ipaddr -> Cstruct.t -> unit Lwt.t
   val connect : IP.t -> t Lwt.t
 end

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "5.0.0"}
+  "mirage-protocols" {>= "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}


### PR DESCRIPTION
TCP and UDP layers (direct & socket):
type ipinput is gone
val handle no longer has a ~listener argument
val listen : t -> ~port:int -> (?keepalive) -> callback -> unit
val unlisten : t -> ~port:int -> unit

On the code level: the listener hash tables moved from stack-* to tcp and udp
(tcp/flow; udp/udp; tcp{v4,v6.v4v6}_socket; udp{v4,v6,v4v6}_socket).

This moved quite some code in the socket stack from the tcpip_stack_socket to
the respective tcp/udp layers.

Adapt to mirage/mirage-protocols#28 changes (that are required); fixes #452

Any review would be highly appreciated. The merge and release plan is to first cut a mirage-protocols release (with exising tcpip getting upper bounds), then a mirage-tcpip release with mirage-protocols lower bound.