### PR TITLE
fix deprecation (listen_tcp{v4}/listen_udp{v4}) since mirage-protocols 6.0.0

### DIFF
--- a/examples/unikernel/services.ml
+++ b/examples/unikernel/services.ml
@@ -42,13 +42,13 @@ module Main (S: Mirage_stack.V4) = struct
 
   let start s =
     (* RFC 862 - read payloads and repeat them back *)
-    S.listen_tcpv4 s ~port:7 echo;
+    S.TCPV4.listen (S.tcpv4 s) ~port:7 echo;
 
     (* RFC 863 - discard all incoming data and never write a payload *)
-    S.listen_tcpv4 s ~port:9 discard;
+    S.TCPV4.listen (S.tcpv4 s) ~port:9 discard;
 
     (* RFC 864 - write data without regard for input *)
-    S.listen_tcpv4 s ~port:19 (fun flow -> chargen flow 75 0);
+    S.TCPV4.listen (S.tcpv4 s) ~port:19 (fun flow -> chargen flow 75 0);
 
     S.listen s
 

--- a/test/test_connect.ml
+++ b/test/test_connect.ml
@@ -62,7 +62,7 @@ module Test_connect (B : Vnetif_backends.Backend) = struct
        failf "connect test timedout after %f seconds" timeout) ;
 
       (V.create_stack ~cidr:server_cidr ~gateway backend >>= fun s1 ->
-       V.Stackv4.listen_tcpv4 s1 ~port:80 (fun f -> accept f test_string);
+       V.Stackv4.TCPV4.listen (V.Stackv4.tcpv4 s1) ~port:80 (fun f -> accept f test_string);
        V.Stackv4.listen s1) ;
 
       (Lwt_unix.sleep 0.1 >>= fun () ->

--- a/test/test_connect_ipv6.ml
+++ b/test/test_connect_ipv6.ml
@@ -63,7 +63,7 @@ module Test_connect_ipv6 (B : Vnetif_backends.Backend) = struct
        failf "connect test timedout after %f seconds" timeout) ;
 
       (V.create_stack_v6 ~cidr:server_cidr backend >>= fun s1 ->
-       V.Stackv6.listen_tcp s1 ~port:80 (fun f -> accept f test_string);
+       V.Stackv6.TCP.listen (V.Stackv6.tcp s1) ~port:80 (fun f -> accept f test_string);
        V.Stackv6.listen s1) ;
 
       (Lwt_unix.sleep 0.1 >>= fun () ->

--- a/test/test_deadlock.ml
+++ b/test/test_deadlock.ml
@@ -116,7 +116,7 @@ let test_digest netif1 netif2 =
           end
         ]
   in
-  TCPIP.listen_tcpv4 (TCPIP.tcpip client_stack) ~port
+  TCPIP.TCPV4.listen TCPIP.(tcpv4 (tcpip client_stack)) ~port
     (fun flow ->
        Client_log.debug (fun f -> f "client got conn");
        let rec consume () =

--- a/test/test_iperf.ml
+++ b/test/test_iperf.ml
@@ -180,7 +180,7 @@ module Test_iperf (B : Vnetif_backends.Backend) = struct
       (Logs.info (fun f -> f  "I am server with IP %a, expecting connections on port %d"
          Ipaddr.V4.pp (V.Stackv4.IPV4.get_ip (V.Stackv4.ipv4 server_s) |> List.hd)
          port);
-       V.Stackv4.listen_tcpv4 server_s ~port (iperf server_s server_done_u);
+       V.Stackv4.TCPV4.listen (V.Stackv4.tcpv4 server_s) ~port (iperf server_s server_done_u);
        Lwt.wakeup server_ready_u ();
        V.Stackv4.listen server_s) ] >>= fun () ->
 

--- a/test/test_iperf_ipv6.ml
+++ b/test/test_iperf_ipv6.ml
@@ -181,7 +181,7 @@ module Test_iperf_ipv6 (B : Vnetif_backends.Backend) = struct
       (Logs.info (fun f -> f  "I am server with IP %a, expecting connections on port %d"
          Ipaddr.V6.pp (V.Stackv6.IP.get_ip (V.Stackv6.ip server_s) |> List.hd)
          port);
-       V.Stackv6.listen_tcp server_s ~port (iperf server_s server_done_u);
+       V.Stackv6.TCP.listen (V.Stackv6.tcp server_s) ~port (iperf server_s server_done_u);
        Lwt.wakeup server_ready_u ();
        V.Stackv6.listen server_s) ] >>= fun () ->
 

--- a/test/test_keepalive.ml
+++ b/test/test_keepalive.ml
@@ -101,7 +101,7 @@ module Test_connect = struct
         failf "connect test timedout after %f seconds" timeout) ;
 
       (V.create_stack ~cidr:server_cidr ~gateway backend >>= fun s1 ->
-        V.Stackv4.listen_tcpv4 s1 ~port:80 (fun f -> accept f);
+        V.Stackv4.TCPV4.listen (V.Stackv4.tcpv4 s1) ~port:80 (fun f -> accept f);
         V.Stackv4.listen s1) ;
 
       (Lwt_unix.sleep 0.1 >>= fun () ->

--- a/test/test_mtus.ml
+++ b/test/test_mtus.ml
@@ -40,7 +40,7 @@ let get_stacks ?client_mtu ?server_mtu backend =
   Lwt.return (server, client)
 
 let start_server ~f server =
-  Stack.Stackv4.listen_tcpv4 server ~port:server_port f;
+  Stack.Stackv4.TCPV4.listen (Stack.Stackv4.tcpv4 server) ~port:server_port f;
   Stack.Stackv4.listen server
 
 let start_client client =

--- a/test/test_socket.ml
+++ b/test/test_socket.ml
@@ -41,7 +41,7 @@ let two_connect_tcp () =
     Stack.disconnect client.stack
   in
 
-  Stack.listen_tcpv4 server.stack ~port:server_port announce;
+  Stack.TCPV4.listen (Stack.tcpv4 server.stack) ~port:server_port announce;
   Lwt.pick [
     Stack.listen server.stack;
     Stack.TCPV4.create_connection client.tcp (localhost, server_port) >|= Result.get_ok >>= fun flow ->
@@ -81,18 +81,18 @@ let icmp_echo_request () =
 
 let no_leak_fds_in_tcpv4 () =
   make_stack ~cidr:localhost_cidr >>= fun stack1 ->
-  Stack.listen_tcpv4 stack1.stack ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stack.TCPV4.listen (Stack.tcpv4 stack1.stack) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stack.disconnect stack1.stack >>= fun () ->
   make_stack ~cidr:localhost_cidr >>= fun stack2 ->
-  Stack.listen_tcpv4 stack2.stack ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stack.TCPV4.listen (Stack.tcpv4 stack2.stack) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stack.disconnect stack2.stack
 
 let no_leak_fds_in_udpv4 () =
   make_stack ~cidr:localhost_cidr >>= fun stack1 ->
-  Stack.listen_udpv4 stack1.stack ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stack.UDPV4.listen (Stack.udpv4 stack1.stack) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stack.disconnect stack1.stack >>= fun () ->
   make_stack ~cidr:localhost_cidr >>= fun stack2 ->
-  Stack.listen_udpv4 stack2.stack ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stack.UDPV4.listen (Stack.udpv4 stack2.stack) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stack.disconnect stack2.stack
 
 module Stackv6 = Tcpip_stack_socket.V6
@@ -105,18 +105,18 @@ let make_v6_stack () =
 
 let no_leak_fds_in_tcpv6 () =
   make_v6_stack () >>= fun stack1 ->
-  Stackv6.listen_tcp stack1 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv6.TCP.listen (Stackv6.tcp stack1) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv6.disconnect stack1 >>= fun () ->
   make_v6_stack () >>= fun stack2 ->
-  Stackv6.listen_tcp stack2 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv6.TCP.listen (Stackv6.tcp stack2) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv6.disconnect stack2
 
 let no_leak_fds_in_udpv6 () =
   make_v6_stack () >>= fun stack1 ->
-  Stackv6.listen_udp stack1 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv6.UDP.listen (Stackv6.udp stack1) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv6.disconnect stack1 >>= fun () ->
   make_v6_stack () >>= fun stack2 ->
-  Stackv6.listen_udp stack2 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv6.UDP.listen (Stackv6.udp stack2) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv6.disconnect stack2
 
 module Stackv4v6 = Tcpip_stack_socket.V4V6
@@ -131,84 +131,84 @@ let ip4_any = Ipaddr.V4.Prefix.global (* 0.0.0.0/0 *)
 
 let no_leak_fds_in_tcpv4v6 () =
   make_v4v6_stack false false ip4_any None >>= fun stack1 ->
-  Stackv4v6.listen_tcp stack1 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack1) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false false ip4_any None >>= fun stack2 ->
-  Stackv4v6.listen_tcp stack2 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack2) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_udpv4v6 () =
   make_v4v6_stack false false ip4_any None >>= fun stack1 ->
-  Stackv4v6.listen_udp stack1 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack1) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false false ip4_any None >>= fun stack2 ->
-  Stackv4v6.listen_udp stack2 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack2) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_tcpv4v6_2 () =
   make_v4v6_stack false false localhost_cidr None >>= fun stack1 ->
-  Stackv4v6.listen_tcp stack1 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack1) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false false localhost_cidr None >>= fun stack2 ->
-  Stackv4v6.listen_tcp stack2 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack2) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_udpv4v6_2 () =
   make_v4v6_stack false false localhost_cidr None >>= fun stack1 ->
-  Stackv4v6.listen_udp stack1 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack1) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false false localhost_cidr None >>= fun stack2 ->
-  Stackv4v6.listen_udp stack2 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack2) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let ip6_local = Some Ipaddr.V6.(Prefix.of_addr localhost)
 
 let no_leak_fds_in_tcpv4v6_3 () =
   make_v4v6_stack false false localhost_cidr ip6_local >>= fun stack1 ->
-  Stackv4v6.listen_tcp stack1 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack1) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false false localhost_cidr ip6_local >>= fun stack2 ->
-  Stackv4v6.listen_tcp stack2 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack2) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_udpv4v6_3 () =
   make_v4v6_stack false false localhost_cidr ip6_local >>= fun stack1 ->
-  Stackv4v6.listen_udp stack1 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack1) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false false localhost_cidr ip6_local >>= fun stack2 ->
-  Stackv4v6.listen_udp stack2 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack2) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_tcpv4v6_4 () =
   make_v4v6_stack true false localhost_cidr ip6_local >>= fun stack1 ->
-  Stackv4v6.listen_tcp stack1 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack1) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack true false localhost_cidr ip6_local >>= fun stack2 ->
-  Stackv4v6.listen_tcp stack2 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack2) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_udpv4v6_4 () =
   make_v4v6_stack true false localhost_cidr ip6_local >>= fun stack1 ->
-  Stackv4v6.listen_udp stack1 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack1) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack true false localhost_cidr ip6_local >>= fun stack2 ->
-  Stackv4v6.listen_udp stack2 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack2) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_tcpv4v6_5 () =
   make_v4v6_stack false true localhost_cidr ip6_local >>= fun stack1 ->
-  Stackv4v6.listen_tcp stack1 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack1) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false true localhost_cidr ip6_local >>= fun stack2 ->
-  Stackv4v6.listen_tcp stack2 ~port:1234 (fun _flow -> Lwt.return_unit);
+  Stackv4v6.TCP.listen (Stackv4v6.tcp stack2) ~port:1234 (fun _flow -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let no_leak_fds_in_udpv4v6_5 () =
   make_v4v6_stack false true localhost_cidr ip6_local >>= fun stack1 ->
-  Stackv4v6.listen_udp stack1 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack1) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack1 >>= fun () ->
   make_v4v6_stack false true localhost_cidr ip6_local >>= fun stack2 ->
-  Stackv4v6.listen_udp stack2 ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
+  Stackv4v6.UDP.listen (Stackv4v6.udp stack2) ~port:1234 (fun ~src:_ ~dst:_ ~src_port:_ _cs -> Lwt.return_unit);
   Stackv4v6.disconnect stack2
 
 let suite = [


### PR DESCRIPTION
fixes #458