### PR TITLE
move Mirage_protocols and Mirage_stack into tcpip directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+### v7.0.0 (2021-12-10)
+
+* Fix memory leak in processing RST packets (#460 @balrajsingh, reported in
+  #456 by @dinosaure)
+* Move module types (IP, UDP, TCP, STACK, ICMP) into tcpip core library
+  (#463 @hannesm)
+* API breakage: Tcpip_checksum is now part of tcpip.checksum (used to be
+  part of tcpip #463 @hannesm)
+* API breakage: tcpip.unix has been removed (#463 @hannesm)
+* Use Lwt.pause instead of deprecated Lwt_{unix,main}.yield (#461 @dinosaure)
+
 ### v6.4.0 (2021-11-11)
 
 * Adapt to mirage-protocols 6.0.0 API (#457 @hannesm)

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,0 +1,6 @@
+(library
+ (name tcpip)
+ (public_name tcpip)
+ (instrumentation
+  (backend bisect_ppx))
+ (libraries cstruct lwt fmt ipaddr mirage-flow duration))

--- a/src/core/ip.ml
+++ b/src/core/ip.ml
@@ -1,0 +1,34 @@
+type error = [
+  | `No_route of string (** can't send a message to that destination *)
+  | `Would_fragment
+]
+let pp_error ppf = function
+  | `No_route s -> Fmt.pf ppf "no route to destination: %s" s
+  | `Would_fragment -> Fmt.string ppf "would fragment"
+
+type proto = [ `TCP | `UDP | `ICMP ]
+let pp_proto ppf = function
+  | `TCP -> Fmt.string ppf "TCP"
+  | `UDP -> Fmt.string ppf "UDP"
+  | `ICMP -> Fmt.string ppf "ICMP"
+
+module type S = sig
+  type nonrec error = private [> error]
+  val pp_error: error Fmt.t
+  type ipaddr
+  val pp_ipaddr : ipaddr Fmt.t
+  type t
+  val disconnect : t -> unit Lwt.t
+  type callback = src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  val input:
+    t ->
+    tcp:callback -> udp:callback -> default:(proto:int -> callback) ->
+    Cstruct.t -> unit Lwt.t
+  val write: t -> ?fragment:bool -> ?ttl:int ->
+    ?src:ipaddr -> ipaddr -> proto -> ?size:int -> (Cstruct.t -> int) ->
+    Cstruct.t list -> (unit, error) result Lwt.t
+  val pseudoheader : t -> ?src:ipaddr -> ipaddr -> proto -> int -> Cstruct.t
+  val src: t -> dst:ipaddr -> ipaddr
+  val get_ip: t -> ipaddr list
+  val mtu: t -> dst:ipaddr -> int
+end

--- a/src/core/ip.mli
+++ b/src/core/ip.mli
@@ -1,0 +1,86 @@
+(** {2 IP layer} *)
+
+(** IP errors and protocols. *)
+type error = [
+  | `No_route of string (** can't send a message to that destination *)
+  | `Would_fragment (** would need to fragment, but fragmentation is disabled *)
+]
+
+val pp_error : error Fmt.t
+
+type proto = [ `TCP | `UDP | `ICMP ]
+val pp_proto: proto Fmt.t
+
+(** An Internet Protocol (IP) layer reassembles IP fragments into packets,
+   removes the IP header, and on the sending side fragments overlong payload
+   and inserts IP headers. *)
+module type S = sig
+
+  type nonrec error = private [> error]
+  (** The type for IP errors. *)
+
+  val pp_error: error Fmt.t
+  (** [pp_error] is the pretty-printer for errors. *)
+
+  type ipaddr
+  (** The type for IP addresses. *)
+
+  val pp_ipaddr : ipaddr Fmt.t
+  (** [pp_ipaddr] is the pretty-printer for IP addresses. *)
+
+  type t
+  (** The type representing the internal state of the IP layer. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the IP layer. While this might take some time to
+      complete, it can never result in an error. *)
+
+  type callback = src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  (** An input continuation used by the parsing functions to pass on
+      an input packet down the stack.
+
+      [callback ~src ~dst buf] will be called with [src] and [dst]
+      containing the source and destination IP address respectively,
+      and [buf] will be a buffer pointing at the start of the IP
+      payload. *)
+
+  val input:
+    t ->
+    tcp:callback -> udp:callback -> default:(proto:int -> callback) ->
+    Cstruct.t -> unit Lwt.t
+  (** [input ~tcp ~udp ~default ip buf] demultiplexes an incoming
+      [buffer] that contains an IP frame. It examines the protocol
+      header and passes the result onto either the [tcp] or [udp]
+      function, or the [default] function for unknown IP protocols. *)
+
+  val write: t -> ?fragment:bool -> ?ttl:int ->
+    ?src:ipaddr -> ipaddr -> proto -> ?size:int -> (Cstruct.t -> int) ->
+    Cstruct.t list -> (unit, error) result Lwt.t
+  (** [write t ~fragment ~ttl ~src dst proto ~size headerf payload] allocates a
+     buffer, writes the IP header, and calls the headerf function. This may
+     write to the provided buffer of [size] (default 0). If [size + ip header]
+     exceeds the maximum transfer unit, an error is returned. The [payload] is
+     appended. The optional [fragment] argument defaults to [true], in which
+     case multiple IP-fragmented frames are sent if the payload is too big for a
+     single frame. When it is [false], the don't fragment bit is set and if the
+     payload and header would exceed the maximum transfer unit, an error is
+     returned. *)
+
+  val pseudoheader : t -> ?src:ipaddr -> ipaddr -> proto -> int -> Cstruct.t
+  (** [pseudoheader t ~src dst proto len] gives a pseudoheader suitable for use in
+      TCP or UDP checksum calculation based on [t]. *)
+
+  val src: t -> dst:ipaddr -> ipaddr
+  (** [src ip ~dst] is the source address to be used to send a
+      packet to [dst].  In the case of IPv4, this will always return
+      the same IP, which is the only one set. *)
+
+  val get_ip: t -> ipaddr list
+  (** Get the IP addresses associated with this interface. For IPv4, only
+      one IP address can be set at a time, so the list will always be of
+      length 1 (and may be the default value, 0.0.0.0). *)
+
+  val mtu: t -> dst:ipaddr -> int
+  (** [mtu ~dst ip] is the Maximum Transmission Unit of the [ip] i.e. the
+      maximum size of the payload, not including the IP header. *)
+end

--- a/src/core/stack.ml
+++ b/src/core/stack.ml
@@ -1,0 +1,156 @@
+module type V4 = sig
+
+  type t
+  (** The type representing the internal state of the IPv4 stack. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the IPv4 stack. While this might take some time to
+      complete, it can never result in an error. *)
+
+  module UDPV4: Udp.S with type ipaddr = Ipaddr.V4.t
+
+  module TCPV4: Tcp.S with type ipaddr = Ipaddr.V4.t
+
+  module IPV4: Ip.S with type ipaddr = Ipaddr.V4.t
+
+  val udpv4: t -> UDPV4.t
+  (** [udpv4 t] obtains a descriptor for use with the [UDPV4] module,
+      usually to transmit traffic. *)
+
+  val tcpv4: t -> TCPV4.t
+  (** [tcpv4 t] obtains a descriptor for use with the [TCPV4] module,
+      usually to initiate outgoing connections. *)
+
+  val ipv4: t -> IPV4.t
+  (** [ipv4 t] obtains a descriptor for use with the [IPV4] module,
+      which can handle raw IPv4 frames, or manipulate IP address
+      configuration on the stack interface. *)
+
+  val listen_udpv4: t -> port:int -> UDPV4.callback -> unit
+  [@@ocaml.deprecated "use UDPV4.listen instead (since mirage-protocols 6.0.0)."]
+  (** [listen_udpv4 t ~port cb] registers the [cb] callback on the
+      UDPv4 [port] and immediately return.  If [port] is invalid (not
+      between 0 and 65535 inclusive), it raises [Invalid_argument].
+      Multiple bindings to the same port will overwrite previous
+      bindings, so callbacks will not chain if ports clash. *)
+
+  val listen_tcpv4: ?keepalive:Tcp.Keepalive.t
+    -> t -> port:int -> (TCPV4.flow -> unit Lwt.t) -> unit
+  [@@ocaml.deprecated "use TCPV4.listen instead (since mirage-protocols 6.0.0)."]
+  (** [listen_tcpv4 ~keepalive t ~port cb] registers the [cb] callback
+      on the TCPv4 [port] and immediately return.  If [port] is invalid (not
+      between 0 and 65535 inclusive), it raises [Invalid_argument].
+      Multiple bindings to the same port will overwrite previous
+      bindings, so callbacks will not chain if ports clash.
+      If [~keepalive] is provided then these keepalive settings will be
+      applied to the accepted connections before the callback is called. *)
+
+  val listen: t -> unit Lwt.t
+  (** [listen t] requests that the stack listen for traffic on the
+      network interface associated with the stack, and demultiplex
+      traffic to the appropriate callbacks. *)
+end
+
+module type V6 = sig
+  type t
+  (** The type representing the internal state of the IPv6 stack. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the IPv6 stack. While this might take some time to
+      complete, it can never result in an error. *)
+
+  module UDP: Udp.S with type ipaddr = Ipaddr.V6.t
+
+  module TCP: Tcp.S with type ipaddr = Ipaddr.V6.t
+
+  module IP: Ip.S with type ipaddr = Ipaddr.V6.t
+
+  val udp: t -> UDP.t
+  (** [udp t] obtains a descriptor for use with the [UDPV6] module,
+      usually to transmit traffic. *)
+
+  val tcp: t -> TCP.t
+  (** [tcp t] obtains a descriptor for use with the [TCPV6] module,
+      usually to initiate outgoing connections. *)
+
+  val ip: t -> IP.t
+  (** [ip t] obtains a descriptor for use with the [IPV6] module,
+      which can handle raw IPv6 frames, or manipulate IP address
+      configuration on the stack interface. *)
+
+  val listen_udp: t -> port:int -> UDP.callback -> unit
+  [@@ocaml.deprecated "use UDP.listen instead (since mirage-protocols 6.0.0)."]
+  (** [listen_udp t ~port cb] registers the [cb] callback on the
+      UDPv6 [port] and immediately return.  If [port] is invalid (not
+      between 0 and 65535 inclusive), it raises [Invalid_argument].
+      Multiple bindings to the same port will overwrite previous
+      bindings, so callbacks will not chain if ports clash. *)
+
+  val listen_tcp: ?keepalive:Tcp.Keepalive.t
+    -> t -> port:int -> (TCP.flow -> unit Lwt.t) -> unit
+  [@@ocaml.deprecated "use TCP.listen instead (since mirage-protocols 6.0.0)."]
+  (** [listen_tcp ~keepalive t ~port cb] registers the [cb] callback
+      on the TCPv6 [port] and immediately return.  If [port] is invalid (not
+      between 0 and 65535 inclusive), it raises [Invalid_argument].
+      Multiple bindings to the same port will overwrite previous
+      bindings, so callbacks will not chain if ports clash.
+      If [~keepalive] is provided then these keepalive settings will be
+      applied to the accepted connections before the callback is called. *)
+
+  val listen: t -> unit Lwt.t
+  (** [listen t] requests that the stack listen for traffic on the
+      network interface associated with the stack, and demultiplex
+      traffic to the appropriate callbacks. *)
+end
+
+module type V4V6 = sig
+  type t
+  (** The type representing the internal state of the dual IPv4 and IPv6 stack. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the dual IPv4 and IPv6 stack. While this might take some
+      time to complete, it can never result in an error. *)
+
+  module UDP: Udp.S with type ipaddr = Ipaddr.t
+
+  module TCP: Tcp.S with type ipaddr = Ipaddr.t
+
+  module IP: Ip.S with type ipaddr = Ipaddr.t
+
+  val udp: t -> UDP.t
+  (** [udp t] obtains a descriptor for use with the [UDP] module,
+      usually to transmit traffic. *)
+
+  val tcp: t -> TCP.t
+  (** [tcp t] obtains a descriptor for use with the [TCP] module,
+      usually to initiate outgoing connections. *)
+
+  val ip: t -> IP.t
+  (** [ip t] obtains a descriptor for use with the [IP] module,
+      which can handle raw IPv4 and IPv6 frames, or manipulate IP address
+      configuration on the stack interface. *)
+
+  val listen_udp: t -> port:int -> UDP.callback -> unit
+  [@@ocaml.deprecated "use UDP.listen instead (since mirage-protocols 6.0.0)."]
+  (** [listen_udp t ~port cb] registers the [cb] callback on the
+      UDP [port] and immediately return.  If [port] is invalid (not
+      between 0 and 65535 inclusive), it raises [Invalid_argument].
+      Multiple bindings to the same port will overwrite previous
+      bindings, so callbacks will not chain if ports clash. *)
+
+  val listen_tcp: ?keepalive:Tcp.Keepalive.t
+    -> t -> port:int -> (TCP.flow -> unit Lwt.t) -> unit
+  [@@ocaml.deprecated "use TCP.listen instead (since mirage-protocols 6.0.0)."]
+  (** [listen_tcp ~keepalive t ~port cb] registers the [cb] callback
+      on the TCP [port] and immediately return.  If [port] is invalid (not
+      between 0 and 65535 inclusive), it raises [Invalid_argument].
+      Multiple bindings to the same port will overwrite previous
+      bindings, so callbacks will not chain if ports clash.
+      If [~keepalive] is provided then these keepalive settings will be
+      applied to the accepted connections before the callback is called. *)
+
+  val listen: t -> unit Lwt.t
+  (** [listen t] requests that the stack listen for traffic on the
+      network interface associated with the stack, and demultiplex
+      traffic to the appropriate callbacks. *)
+end

--- a/src/core/tcp.ml
+++ b/src/core/tcp.ml
@@ -1,0 +1,39 @@
+type error = [ `Timeout | `Refused]
+type write_error = [ error | Mirage_flow.write_error]
+
+let pp_error ppf = function
+  | `Timeout -> Fmt.string ppf "connection attempt timed out"
+  | `Refused -> Fmt.string ppf "connection attempt was refused"
+
+let pp_write_error ppf = function
+  | #Mirage_flow.write_error as e -> Mirage_flow.pp_write_error ppf e
+  | #error as e                   -> pp_error ppf e
+
+module Keepalive = struct
+  type t = {
+    after: Duration.t;
+    interval: Duration.t;
+    probes: int;
+  }
+end
+
+module type S = sig
+  type nonrec error = private [> error]
+  type nonrec write_error = private [> write_error]
+  type ipaddr
+  type flow
+  type t
+  val disconnect : t -> unit Lwt.t
+  include Mirage_flow.S with
+      type flow   := flow
+  and type error  := error
+  and type write_error := write_error
+
+  val dst: flow -> ipaddr * int
+  val write_nodelay: flow -> Cstruct.t -> (unit, write_error) result Lwt.t
+  val writev_nodelay: flow -> Cstruct.t list -> (unit, write_error) result Lwt.t
+  val create_connection: ?keepalive:Keepalive.t -> t -> ipaddr * int -> (flow, error) result Lwt.t
+  val listen : t -> port:int -> ?keepalive:Keepalive.t -> (flow -> unit Lwt.t) -> unit
+  val unlisten : t -> port:int -> unit
+  val input: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+end

--- a/src/core/tcp.mli
+++ b/src/core/tcp.mli
@@ -1,0 +1,95 @@
+type error = [ `Timeout | `Refused]
+type write_error = [ error | Mirage_flow.write_error ]
+
+val pp_error : error Fmt.t
+val pp_write_error : write_error Fmt.t
+
+(** Configuration for TCP keep-alives.
+    Keep-alive messages are probes sent on an idle connection. If no traffic
+    is received after a certain number of probes are sent, then the connection
+    is assumed to have been lost. *)
+module Keepalive: sig
+  type t = {
+    after: Duration.t;    (** initial delay before sending probes on an idle
+                              connection *)
+    interval: Duration.t; (** interval between successive probes *)
+    probes: int;          (** total number of probes to send before assuming
+                              that, if the connection is still idle it has
+                              been lost *)
+  }
+  (** Configuration for TCP keep-alives *)
+end
+
+(** Transmission Control Protocol layer: reliable ordered streaming
+    communication. *)
+module type S = sig
+
+  type nonrec error = private [> error]
+  (** The type for TCP errors. *)
+
+  type nonrec write_error = private [> write_error]
+  (** The type for TCP write errors. *)
+
+  type ipaddr
+  (** The type for IP address representations. *)
+
+  type flow
+  (** A flow represents the state of a single TCP stream that is connected
+      to an endpoint. *)
+
+  type t
+  (** The type representing the internal state of the TCP layer. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the TCP layer. While this might take some time to
+      complete, it can never result in an error. *)
+
+  include Mirage_flow.S with
+      type flow   := flow
+  and type error  := error
+  and type write_error := write_error
+
+  val dst: flow -> ipaddr * int
+  (** Get the destination IP address and destination port that a
+      flow is currently connected to. *)
+
+  val write_nodelay: flow -> Cstruct.t -> (unit, write_error) result Lwt.t
+  (** [write_nodelay flow buffer] writes the contents of [buffer]
+      to the flow. The thread blocks until all data has been successfully
+      transmitted to the remote endpoint.
+      Buffering within the layer is minimized in this mode.
+      Note that this API will change in a future revision to be a
+      per-flow attribute instead of a separately exposed function. *)
+
+  val writev_nodelay: flow -> Cstruct.t list -> (unit, write_error) result Lwt.t
+  (** [writev_nodelay flow buffers] writes the contents of [buffers]
+      to the flow. The thread blocks until all data has been successfully
+      transmitted to the remote endpoint.
+      Buffering within the layer is minimized in this mode.
+      Note that this API will change in a future revision to be a
+      per-flow attribute instead of a separately exposed function. *)
+
+  val create_connection: ?keepalive:Keepalive.t -> t -> ipaddr * int -> (flow, error) result Lwt.t
+  (** [create_connection ~keepalive t (addr,port)] opens a TCP connection
+      to the specified endpoint.
+
+      If the optional argument [?keepalive] is provided then TCP keep-alive
+      messages will be sent to the server when the connection is idle. If
+      no responses are received then eventually the connection will be disconnected:
+      [read] will return [Ok `Eof] and write will return [Error `Closed] *)
+
+  val listen : t -> port:int -> ?keepalive:Keepalive.t -> (flow -> unit Lwt.t) -> unit
+  (** [listen t ~port ~keepalive callback] listens on [port]. The [callback] is
+      executed for each flow that was established. If [keepalive] is provided,
+      this configuration will be applied before calling [callback].
+
+      @raise Invalid_argument if [port < 0] or [port > 65535]
+ *)
+
+  val unlisten : t -> port:int -> unit
+  (** [unlisten t ~port] stops any listener on [port]. *)
+
+  val input: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  (** [input t] returns an input function continuation to be
+      passed to the underlying {!IP} layer. *)
+end

--- a/src/core/udp.ml
+++ b/src/core/udp.ml
@@ -1,0 +1,13 @@
+module type S = sig
+  type error
+  val pp_error: error Fmt.t
+  type ipaddr
+  type t
+  val disconnect : t -> unit Lwt.t
+  type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lwt.t
+  val listen : t -> port:int -> callback -> unit
+  val unlisten : t -> port:int -> unit
+  val input: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  val write: ?src:ipaddr -> ?src_port:int -> ?ttl:int -> dst:ipaddr -> dst_port:int -> t -> Cstruct.t ->
+    (unit, error) result Lwt.t
+end

--- a/src/core/udp.mli
+++ b/src/core/udp.mli
@@ -1,0 +1,46 @@
+(** User datagram protocol layer: connectionless message-oriented
+    communication. *)
+module type S = sig
+
+  type error (* entirely abstract since we expose none in a Udp module *)
+  (** The type for UDP errors. *)
+
+  val pp_error: error Fmt.t
+  (** [pp] is the pretty-printer for errors. *)
+
+  type ipaddr
+  (** The type for an IP address representations. *)
+
+  type t
+  (** The type representing the internal state of the UDP layer. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the UDP layer. While this might take some time to
+      complete, it can never result in an error. *)
+
+  type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lwt.t
+  (** The type for callback functions that adds the UDP metadata for
+      [src] and [dst] IP addresses, the [src_port] of the
+      connection and the [buffer] payload of the datagram. *)
+
+  val listen : t -> port:int -> callback -> unit
+  (** [listen t ~port callback] executes [callback] for each packet received
+      on [port].
+
+      @raise Invalid_argument if [port < 0] or [port > 65535] *)
+
+  val unlisten : t -> port:int -> unit
+  (** [unlisten t ~port] stops any listeners on [port]. *)
+
+  val input: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  (** [input t] demultiplexes incoming datagrams based on
+      their destination port. *)
+
+  val write: ?src:ipaddr -> ?src_port:int -> ?ttl:int -> dst:ipaddr ->
+    dst_port:int -> t -> Cstruct.t -> (unit, error) result Lwt.t
+  (** [write ~src ~src_port ~ttl ~dst ~dst_port udp data] is a task
+      that writes [data] from an optional [src] and [src_port] to a [dst]
+      and [dst_port] IP address pair. An optional time-to-live ([ttl]) is passed
+      through to the IP layer. *)
+
+end

--- a/src/icmp/dune
+++ b/src/icmp/dune
@@ -3,7 +3,7 @@
  (public_name tcpip.icmpv4)
  (instrumentation
   (backend bisect_ppx))
- (libraries mirage-protocols logs tcpip mirage-profile tcpip.udp)
+ (libraries logs tcpip mirage-profile ipaddr tcpip.checksum)
  (preprocess
   (pps ppx_cstruct))
  (wrapped false))

--- a/src/icmp/icmpv4.ml
+++ b/src/icmp/icmpv4.ml
@@ -1,9 +1,19 @@
+module type S = sig
+  type t
+  val disconnect : t -> unit Lwt.t
+  type ipaddr = Ipaddr.V4.t
+  type error
+  val pp_error: error Fmt.t
+  val input : t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  val write : t -> ?src:ipaddr -> dst:ipaddr -> ?ttl:int -> Cstruct.t -> (unit, error) result Lwt.t
+end
+
 open Lwt.Infix
 
 let src = Logs.Src.create "icmpv4" ~doc:"Mirage ICMPv4"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(IP : Mirage_protocols.IP with type ipaddr = Ipaddr.V4.t) = struct
+module Make (IP : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t) = struct
 
   type ipaddr = Ipaddr.V4.t
 

--- a/src/icmp/icmpv4.mli
+++ b/src/icmp/icmpv4.mli
@@ -1,5 +1,36 @@
-module Make (I:Mirage_protocols.IP with type ipaddr = Ipaddr.V4.t) : sig
-  include Mirage_protocols.ICMP with type ipaddr = Ipaddr.V4.t
+(** {2 ICMP layer} *)
+
+(** Internet Control Message Protocol: error messages and operational
+    information. *)
+module type S = sig
+
+  type t
+  (** The type representing the internal state of the ICMP layer. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the ICMP layer. While this might take some time to
+      complete, it can never result in an error. *)
+
+  type ipaddr = Ipaddr.V4.t
+  (** The type for IP addresses. *)
+
+  type error (* entirely abstract since we expose none in an Icmp module *)
+  (** The type for ICMP errors. *)
+
+  val pp_error: error Fmt.t
+  (** [pp_error] is the pretty-printer for errors. *)
+
+  val input : t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
+  (** [input t src dst buffer] reacts to the ICMP message in
+      [buffer]. *)
+
+  val write : t -> ?src:ipaddr -> dst:ipaddr -> ?ttl:int -> Cstruct.t -> (unit, error) result Lwt.t
+  (** [write t ~src ~dst ~ttl buffer] sends the ICMP message in [buffer] to [dst]
+      over IP. Passes the time-to-live ([ttl]) to the IP stack if given. *)
+end
+
+module Make (I : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t) : sig
+  include S
 
   val connect : I.t -> t Lwt.t
 end

--- a/src/ipv4/dune
+++ b/src/ipv4/dune
@@ -3,8 +3,8 @@
  (public_name tcpip.ipv4)
  (instrumentation
   (backend bisect_ppx))
- (libraries logs mirage-protocols ipaddr cstruct tcpip tcpip.udp
-   mirage-random mirage-clock randomconv lru)
+ (libraries logs ipaddr cstruct tcpip tcpip.udp tcpip.checksum mirage-random
+   mirage-clock randomconv lru arp.mirage ethernet)
  (preprocess
   (pps ppx_cstruct))
  (wrapped false))

--- a/src/ipv4/routing.ml
+++ b/src/ipv4/routing.ml
@@ -12,7 +12,7 @@ let mac_of_multicast ip =
 
 type routing_error = [ `Local | `Gateway ]
 
-module Make(Log : Logs.LOG) (A : Mirage_protocols.ARP) = struct
+module Make(Log : Logs.LOG) (A : Arp.S) = struct
 
   open Lwt.Infix
 

--- a/src/ipv4/static_ipv4.ml
+++ b/src/ipv4/static_ipv4.ml
@@ -19,13 +19,13 @@ open Lwt.Infix
 let src = Logs.Src.create "ipv4" ~doc:"Mirage IPv4"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (Ethernet: Mirage_protocols.ETHERNET) (Arpv4 : Mirage_protocols.ARP) = struct
+module Make (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
   module Routing = Routing.Make(Log)(Arpv4)
 
   (** IO operation errors *)
-  type error = [ Mirage_protocols.Ip.error | `Would_fragment | `Ethif of Ethernet.error ]
+  type error = [ Tcpip.Ip.error | `Would_fragment | `Ethif of Ethernet.error ]
   let pp_error ppf = function
-    | #Mirage_protocols.Ip.error as e -> Mirage_protocols.Ip.pp_error ppf e
+    | #Tcpip.Ip.error as e -> Tcpip.Ip.pp_error ppf e
     | `Ethif e -> Ethernet.pp_error ppf e
 
   type ipaddr = Ipaddr.V4.t

--- a/src/ipv4/static_ipv4.mli
+++ b/src/ipv4/static_ipv4.mli
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (E: Mirage_protocols.ETHERNET) (A: Mirage_protocols.ARP) : sig
-  include Mirage_protocols.IP with type ipaddr = Ipaddr.V4.t
+module Make (R: Mirage_random.S) (C: Mirage_clock.MCLOCK) (E: Ethernet.S) (A: Arp.S) : sig
+  include Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t
 
   val connect : ?no_init:bool -> cidr:Ipaddr.V4.Prefix.t -> ?gateway:Ipaddr.V4.t ->
     ?fragment_cache_size:int -> E.t -> A.t -> t Lwt.t

--- a/src/ipv6/dune
+++ b/src/ipv6/dune
@@ -3,7 +3,7 @@
  (public_name tcpip.ipv6)
  (instrumentation
   (backend bisect_ppx))
- (libraries logs mirage-protocols mirage-time mirage-net macaddr-cstruct
+ (libraries logs mirage-time mirage-net macaddr-cstruct tcpip.checksum
    mirage-clock duration ipaddr cstruct mirage-random tcpip randomconv
    ethernet)
  (preprocess

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -22,7 +22,7 @@ module I = Ipaddr
 open Lwt.Infix
 
 module Make (N : Mirage_net.S)
-            (E : Mirage_protocols.ETHERNET)
+            (E : Ethernet.S)
             (R : Mirage_random.S)
             (T : Mirage_time.S)
             (C : Mirage_clock.MCLOCK) = struct
@@ -35,10 +35,10 @@ module Make (N : Mirage_net.S)
     { ethif : E.t;
       mutable ctx : Ndpv6.context }
 
-  type error = [ Mirage_protocols.Ip.error | `Ethif of E.error ]
+  type error = [ Tcpip.Ip.error | `Ethif of E.error ]
 
   let pp_error ppf = function
-    | #Mirage_protocols.Ip.error as e -> Mirage_protocols.Ip.pp_error ppf e
+    | #Tcpip.Ip.error as e -> Tcpip.Ip.pp_error ppf e
     | `Ethif e -> E.pp_error ppf e
 
   let output t (dst, size, fill) =
@@ -160,7 +160,7 @@ module Make (N : Mirage_net.S)
         (* MCP: replace this error swallowing with proper propagation *)
         (Lwt_list.iter_s (output_ign t) outs >>= fun () ->
          task) ;
-        (N.listen netif ~header_size:Ethernet_wire.sizeof_ethernet ethif_listener >|= fun _ -> ()) ;
+        (N.listen netif ~header_size:Ethernet.Packet.sizeof_ethernet ethif_listener >|= fun _ -> ()) ;
         timeout
       ] >>= fun () ->
       let expected_ips = match cidr with None -> 1 | Some _ -> 2 in

--- a/src/ipv6/ipv6.mli
+++ b/src/ipv6/ipv6.mli
@@ -15,11 +15,11 @@
  *)
 
 module Make (N : Mirage_net.S)
-            (E : Mirage_protocols.ETHERNET)
+            (E : Ethernet.S)
             (R : Mirage_random.S)
             (T : Mirage_time.S)
             (Clock : Mirage_clock.MCLOCK) : sig
-  include Mirage_protocols.IP with type ipaddr = Ipaddr.V6.t
+  include Tcpip.Ip.S with type ipaddr = Ipaddr.V6.t
   val connect :
     ?no_init:bool ->
     ?handle_ra:bool ->

--- a/src/ipv6/ndpv6.mli
+++ b/src/ipv6/ndpv6.mli
@@ -55,7 +55,7 @@ val handle : now:time -> random:(int -> Cstruct.t) -> context -> buffer ->
     packets to be sent and [evs] is a list of packets to be passed to the higher
     layers (udp, tcp, etc) for further processing. *)
 
-val send : now:time -> context -> ?src:ipaddr -> ipaddr -> Mirage_protocols.Ip.proto ->
+val send : now:time -> context -> ?src:ipaddr -> ipaddr -> Tcpip.Ip.proto ->
   int -> (buffer -> buffer -> int) -> context * (Macaddr.t * int * (buffer -> int)) list
 (** [send ~now ctx ?src dst proto size fillf] starts route resolution and assembles an
     ipv6 packet of [size] for sending with header and body passed to [fillf].

--- a/src/stack-direct/dune
+++ b/src/stack-direct/dune
@@ -3,5 +3,5 @@
  (public_name tcpip.stack-direct)
  (instrumentation
   (backend bisect_ppx))
- (libraries logs ipaddr lwt fmt mirage-time mirage-random mirage-protocols
-   mirage-stack mirage-net ethernet))
+ (libraries logs ipaddr lwt fmt mirage-time mirage-random mirage-net ethernet
+   arp.mirage tcpip.icmpv4 tcpip.udp tcpip.tcp))

--- a/src/stack-direct/tcpip_stack_direct.mli
+++ b/src/stack-direct/tcpip_stack_direct.mli
@@ -14,23 +14,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type UDPV4_DIRECT = Mirage_protocols.UDP
-  with type ipaddr = Ipaddr.V4.t
-
-module type TCPV4_DIRECT = Mirage_protocols.TCP
-  with type ipaddr = Ipaddr.V4.t
-
 module Make
     (Time     : Mirage_time.S)
     (Random   : Mirage_random.S)
     (Netif    : Mirage_net.S)
-    (Ethernet : Mirage_protocols.ETHERNET)
-    (Arpv4    : Mirage_protocols.ARP)
-    (Ipv4     : Mirage_protocols.IP with type ipaddr = Ipaddr.V4.t)
-    (Icmpv4   : Mirage_protocols.ICMP with type ipaddr = Ipaddr.V4.t)
-    (Udpv4    : UDPV4_DIRECT)
-    (Tcpv4    : TCPV4_DIRECT) : sig
-  include Mirage_stack.V4
+    (Ethernet : Ethernet.S)
+    (Arpv4    : Arp.S)
+    (Ipv4     : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t)
+    (Icmpv4   : Icmpv4.S)
+    (Udpv4    : Tcpip.Udp.S with type ipaddr = Ipaddr.V4.t)
+    (Tcpv4    : Tcpip.Tcp.S with type ipaddr = Ipaddr.V4.t) : sig
+  include Tcpip.Stack.V4
     with module IPV4 = Ipv4
      and module TCPV4 = Tcpv4
      and module UDPV4 = Udpv4
@@ -44,21 +38,15 @@ module Make
       connections, they will be able to do so. *)
 end
 
-module type UDPV6_DIRECT = Mirage_protocols.UDP
-  with type ipaddr = Ipaddr.V6.t
-
-module type TCPV6_DIRECT = Mirage_protocols.TCP
-  with type ipaddr = Ipaddr.V6.t
-
 module MakeV6
     (Time     : Mirage_time.S)
     (Random   : Mirage_random.S)
     (Netif    : Mirage_net.S)
-    (Ethernet : Mirage_protocols.ETHERNET)
-    (Ipv6     : Mirage_protocols.IP with type ipaddr = Ipaddr.V6.t)
-    (Udpv6    : UDPV6_DIRECT)
-    (Tcpv6    : TCPV6_DIRECT) : sig
-  include Mirage_stack.V6
+    (Ethernet : Ethernet.S)
+    (Ipv6     : Tcpip.Ip.S with type ipaddr = Ipaddr.V6.t)
+    (Udpv6    : Tcpip.Udp.S with type ipaddr = Ipaddr.V6.t)
+    (Tcpv6    : Tcpip.Tcp.S with type ipaddr = Ipaddr.V6.t) : sig
+  include Tcpip.Stack.V6
     with module IP = Ipv6
      and module TCP = Tcpv6
      and module UDP = Udpv6
@@ -71,14 +59,8 @@ module MakeV6
       they will be able to do so. *)
 end
 
-module type UDPV4V6_DIRECT = Mirage_protocols.UDP
-  with type ipaddr = Ipaddr.t
-
-module type TCPV4V6_DIRECT = Mirage_protocols.TCP
-  with type ipaddr = Ipaddr.t
-
-module IPV4V6 (Ipv4 : Mirage_protocols.IPV4) (Ipv6 : Mirage_protocols.IPV6) : sig
-  include Mirage_protocols.IP with type ipaddr = Ipaddr.t
+module IPV4V6 (Ipv4 : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t) (Ipv6 : Tcpip.Ip.S with type ipaddr = Ipaddr.V6.t) : sig
+  include Tcpip.Ip.S with type ipaddr = Ipaddr.t
 
   val connect : ipv4_only:bool -> ipv6_only:bool -> Ipv4.t -> Ipv6.t -> t Lwt.t
 end
@@ -87,13 +69,13 @@ module MakeV4V6
     (Time     : Mirage_time.S)
     (Random   : Mirage_random.S)
     (Netif    : Mirage_net.S)
-    (Ethernet : Mirage_protocols.ETHERNET)
-    (Arpv4    : Mirage_protocols.ARP)
-    (Ip       : Mirage_protocols.IP with type ipaddr = Ipaddr.t)
-    (Icmpv4   : Mirage_protocols.ICMP with type ipaddr = Ipaddr.V4.t)
-    (Udp      : UDPV4V6_DIRECT)
-    (Tcp      : TCPV4V6_DIRECT) : sig
-  include Mirage_stack.V4V6
+    (Ethernet : Ethernet.S)
+    (Arpv4    : Arp.S)
+    (Ip       : Tcpip.Ip.S with type ipaddr = Ipaddr.t)
+    (Icmpv4   : Icmpv4.S)
+    (Udp      : Tcpip.Udp.S with type ipaddr = Ipaddr.t)
+    (Tcp      : Tcpip.Tcp.S with type ipaddr = Ipaddr.t) : sig
+  include Tcpip.Stack.V4V6
     with module IP = Ip
      and module TCP = Tcp
      and module UDP = Udp

--- a/src/stack-unix/dune
+++ b/src/stack-unix/dune
@@ -6,7 +6,7 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries lwt.unix ipaddr.unix cstruct-lwt tcpip.icmpv4 tcpip.ipv4
-   tcpip.ipv6 mirage-protocols))
+   tcpip.ipv6))
 
 (library
  (name udpv4_socket)
@@ -15,7 +15,7 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols logs))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt logs))
 
 (library
  (name udpv6_socket)
@@ -24,7 +24,7 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols logs))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt logs))
 
 (library
  (name udpv4v6_socket)
@@ -33,7 +33,7 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols logs))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt logs))
 
 (library
  (name tcp_socket_options)
@@ -55,8 +55,8 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols
-   tcp_socket_options logs))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt tcpip tcp_socket_options
+   logs))
 
 (library
  (name tcpv6_socket)
@@ -65,8 +65,8 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols
-   tcpv4_socket tcp_socket_options logs))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt tcpip tcpv4_socket
+   tcp_socket_options logs))
 
 (library
  (name tcpv4v6_socket)
@@ -75,8 +75,8 @@
  (wrapped false)
  (instrumentation
   (backend bisect_ppx))
- (libraries lwt.unix ipaddr.unix cstruct-lwt fmt mirage-protocols
-   tcpv4_socket tcp_socket_options logs))
+ (libraries lwt.unix ipaddr.unix cstruct-lwt fmt tcpip tcpv4_socket
+   tcp_socket_options logs))
 
 (library
  (name tcpip_stack_socket)
@@ -87,5 +87,4 @@
   (backend bisect_ppx))
  (libraries lwt.unix cstruct-lwt ipaddr.unix logs tcpip.tcpv4-socket
    tcpip.udpv4-socket tcpip.ipv4 tcpip.tcpv6-socket tcpip.udpv6-socket
-   tcpip.ipv6 tcpip.tcpv4v6-socket tcpip.udpv4v6-socket tcpip.icmpv4
-   mirage-protocols mirage-stack))
+   tcpip.ipv6 tcpip.tcpv4v6-socket tcpip.udpv4v6-socket))

--- a/src/stack-unix/icmpv4_socket.mli
+++ b/src/stack-unix/icmpv4_socket.mli
@@ -1,4 +1,4 @@
-include Mirage_protocols.ICMP with type ipaddr = Ipaddr.V4.t
+include Icmpv4.S
 
 val connect : unit -> t Lwt.t
 

--- a/src/stack-unix/ipv4_socket.ml
+++ b/src/stack-unix/ipv4_socket.ml
@@ -15,11 +15,11 @@
  *)
 
 type t = unit
-type error = Mirage_protocols.Ip.error
+type error = Tcpip.Ip.error
 type ipaddr = Ipaddr.V4.t
 type callback = src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
 
-let pp_error = Mirage_protocols.Ip.pp_error
+let pp_error = Tcpip.Ip.pp_error
 let pp_ipaddr = Ipaddr.V4.pp
 
 let mtu _ ~dst:_ = 1500 - Ipv4_wire.sizeof_ipv4

--- a/src/stack-unix/ipv4v6_socket.ml
+++ b/src/stack-unix/ipv4v6_socket.ml
@@ -15,11 +15,11 @@
  *)
 
 type t = unit
-type error = Mirage_protocols.Ip.error
+type error = Tcpip.Ip.error
 type ipaddr = Ipaddr.t
 type callback = src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
 
-let pp_error = Mirage_protocols.Ip.pp_error
+let pp_error = Tcpip.Ip.pp_error
 let pp_ipaddr = Ipaddr.pp
 
 let mtu _ ~dst = match dst with

--- a/src/stack-unix/ipv6_socket.ml
+++ b/src/stack-unix/ipv6_socket.ml
@@ -16,11 +16,11 @@
  *)
 
 type t = unit
-type error = Mirage_protocols.Ip.error
+type error = Tcpip.Ip.error
 type ipaddr = Ipaddr.V6.t
 type callback = src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
 
-let pp_error = Mirage_protocols.Ip.pp_error
+let pp_error = Tcpip.Ip.pp_error
 let pp_ipaddr = Ipaddr.V6.pp
 
 let mtu _ ~dst:_ = 1500 - Ipv6_wire.sizeof_ipv6

--- a/src/stack-unix/tcp_socket.ml
+++ b/src/stack-unix/tcp_socket.ml
@@ -1,14 +1,14 @@
 open Lwt
 
-type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
-type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
+type error = [ Tcpip.Tcp.error | `Exn of exn ]
+type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 let pp_error ppf = function
-  | #Mirage_protocols.Tcp.error as e -> Mirage_protocols.Tcp.pp_error ppf e
+  | #Tcpip.Tcp.error as e -> Tcpip.Tcp.pp_error ppf e
   | `Exn e -> Fmt.exn ppf e
 
 let pp_write_error ppf = function
-  | #Mirage_protocols.Tcp.write_error as e -> Mirage_protocols.Tcp.pp_write_error ppf e
+  | #Tcpip.Tcp.write_error as e -> Tcpip.Tcp.pp_write_error ppf e
   | `Exn e -> Fmt.exn ppf e
 
 let ignore_canceled = function

--- a/src/stack-unix/tcpip_stack_socket.mli
+++ b/src/stack-unix/tcpip_stack_socket.mli
@@ -15,7 +15,7 @@
  *)
 
 module V4 : sig
-  include Mirage_stack.V4
+  include Tcpip.Stack.V4
     with module UDPV4 = Udpv4_socket
      and module TCPV4 = Tcpv4_socket
      and module IPV4  = Ipv4_socket
@@ -23,7 +23,7 @@ module V4 : sig
 end
 
 module V6 : sig
-  include Mirage_stack.V6
+  include Tcpip.Stack.V6
     with module UDP = Udpv6_socket
      and module TCP = Tcpv6_socket
      and module IP  = Ipv6_socket
@@ -31,7 +31,7 @@ module V6 : sig
 end
 
 module V4V6 : sig
-  include Mirage_stack.V4V6
+  include Tcpip.Stack.V4V6
     with module UDP = Udpv4v6_socket
      and module TCP = Tcpv4v6_socket
      and module IP  = Ipv4v6_socket

--- a/src/stack-unix/tcpv4_socket.ml
+++ b/src/stack-unix/tcpv4_socket.ml
@@ -66,7 +66,7 @@ let create_connection ?keepalive t (dst,dst_port) =
       >>= fun () ->
       ( match keepalive with
         | None -> ()
-        | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+        | Some { Tcpip.Tcp.Keepalive.after; interval; probes } ->
           Tcp_socket_options.enable_keepalive ~fd ~after ~interval ~probes );
       t.active_connections <- fd :: t.active_connections;
       Lwt.return (Ok fd))
@@ -100,7 +100,7 @@ let listen t ~port ?keepalive callback =
               t.active_connections <- afd :: t.active_connections;
               (match keepalive with
                | None -> ()
-               | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+               | Some { Tcpip.Tcp.Keepalive.after; interval; probes } ->
                  Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
               Lwt.async
                 (fun () ->

--- a/src/stack-unix/tcpv4_socket.mli
+++ b/src/stack-unix/tcpv4_socket.mli
@@ -14,11 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Mirage_protocols.TCP
+include Tcpip.Tcp.S
   with type ipaddr = Ipaddr.V4.t
    and type flow = Lwt_unix.file_descr
-   and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
-   and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
+   and type error = [ Tcpip.Tcp.error | `Exn of exn ]
+   and type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 val connect : Ipaddr.V4.Prefix.t -> t Lwt.t
 

--- a/src/stack-unix/tcpv4v6_socket.ml
+++ b/src/stack-unix/tcpv4v6_socket.ml
@@ -100,7 +100,7 @@ let create_connection ?keepalive t (dst,dst_port) =
         >>= fun () ->
         ( match keepalive with
           | None -> ()
-          | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+          | Some { Tcpip.Tcp.Keepalive.after; interval; probes } ->
             Tcp_socket_options.enable_keepalive ~fd ~after ~interval ~probes );
         t.active_connections <- fd :: t.active_connections;
         Lwt.return (Ok fd))
@@ -157,7 +157,7 @@ let listen t ~port ?keepalive callback =
                 t.active_connections <- afd :: t.active_connections;
                 (match keepalive with
                  | None -> ()
-                 | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+                 | Some { Tcpip.Tcp.Keepalive.after; interval; probes } ->
                    Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
                 Lwt.async
                   (fun () ->

--- a/src/stack-unix/tcpv4v6_socket.mli
+++ b/src/stack-unix/tcpv4v6_socket.mli
@@ -15,11 +15,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Mirage_protocols.TCP
+include Tcpip.Tcp.S
   with type ipaddr = Ipaddr.t
    and type flow = Lwt_unix.file_descr
-   and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
-   and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
+   and type error = [ Tcpip.Tcp.error | `Exn of exn ]
+   and type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 val connect : ipv4_only:bool -> ipv6_only:bool -> Ipaddr.V4.Prefix.t -> Ipaddr.V6.Prefix.t option -> t Lwt.t
 

--- a/src/stack-unix/tcpv6_socket.ml
+++ b/src/stack-unix/tcpv6_socket.ml
@@ -72,7 +72,7 @@ let create_connection ?keepalive t (dst,dst_port) =
       >>= fun () ->
       ( match keepalive with
         | None -> ()
-        | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+        | Some { Tcpip.Tcp.Keepalive.after; interval; probes } ->
           Tcp_socket_options.enable_keepalive ~fd ~after ~interval ~probes );
       t.active_connections <- fd :: t.active_connections;
       Lwt.return (Ok fd))
@@ -107,7 +107,7 @@ let listen t ~port ?keepalive callback =
             t.active_connections <- afd :: t.active_connections;
             (match keepalive with
              | None -> ()
-             | Some { Mirage_protocols.Keepalive.after; interval; probes } ->
+             | Some { Tcpip.Tcp.Keepalive.after; interval; probes } ->
                Tcp_socket_options.enable_keepalive ~fd:afd ~after ~interval ~probes);
             Lwt.async
               (fun () ->

--- a/src/stack-unix/tcpv6_socket.mli
+++ b/src/stack-unix/tcpv6_socket.mli
@@ -15,11 +15,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-include Mirage_protocols.TCP
+include Tcpip.Tcp.S
   with type ipaddr = Ipaddr.V6.t
    and type flow = Lwt_unix.file_descr
-   and type error = [ Mirage_protocols.Tcp.error | `Exn of exn ]
-   and type write_error = [ Mirage_protocols.Tcp.write_error | `Exn of exn ]
+   and type error = [ Tcpip.Tcp.error | `Exn of exn ]
+   and type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 val connect : Ipaddr.V6.Prefix.t option -> t Lwt.t
 

--- a/src/tcp/dune
+++ b/src/tcp/dune
@@ -3,8 +3,8 @@
  (public_name tcpip.tcp)
  (instrumentation
   (backend bisect_ppx))
- (libraries logs mirage-protocols ipaddr cstruct lwt-dllist mirage-profile
+ (libraries logs ipaddr cstruct lwt-dllist mirage-profile tcpip.checksum
    tcpip duration randomconv fmt mirage-time mirage-clock mirage-random
-   metrics)
+   mirage-flow metrics)
  (preprocess
   (pps ppx_cstruct)))

--- a/src/tcp/flow.mli
+++ b/src/tcp/flow.mli
@@ -14,11 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (IP:Mirage_protocols.IP)
+module Make (IP:Tcpip.Ip.S)
             (TM:Mirage_time.S)
             (C:Mirage_clock.MCLOCK)
             (R:Mirage_random.S) : sig
-  include Mirage_protocols.TCP
-    with type ipaddr = IP.ipaddr
+  include Tcpip.Tcp.S with type ipaddr = IP.ipaddr
   val connect : IP.t -> t Lwt.t
 end

--- a/src/tcp/keepalive.ml
+++ b/src/tcp/keepalive.ml
@@ -29,7 +29,7 @@ let alive = {
 }
 
 let next ~configuration ~ns state =
-  let open Mirage_protocols.Keepalive in
+  let open Tcpip.Tcp.Keepalive in
   let after_ns = configuration.after in
   (* Wait until [time] has gone past *)
   if after_ns > ns
@@ -51,7 +51,7 @@ let next ~configuration ~ns state =
 
   module Make(T:Mirage_time.S)(Clock:Mirage_clock.MCLOCK) = struct
     type t = {
-      configuration: Mirage_protocols.Keepalive.t;
+      configuration: Tcpip.Tcp.Keepalive.t;
       callback: ([ `SendProbe | `Close ] -> unit Lwt.t);
       mutable state: state;
       mutable timer: unit Lwt.t;

--- a/src/tcp/keepalive.mli
+++ b/src/tcp/keepalive.mli
@@ -39,7 +39,7 @@ type state
 val alive: state
 (** An alive connection *)
 
-val next: configuration:Mirage_protocols.Keepalive.t -> ns:int64 -> state -> action * state
+val next: configuration:Tcpip.Tcp.Keepalive.t -> ns:int64 -> state -> action * state
 (** [next ~configuration ~ns state] returns the action we should take given
     that we last received a packet [ns] nanoseconds ago and the new state
     of the connection *)
@@ -48,7 +48,7 @@ module Make(T:Mirage_time.S)(Clock:Mirage_clock.MCLOCK): sig
   type t
   (** A keep-alive timer *)
 
-  val create: Mirage_protocols.Keepalive.t -> ([ `SendProbe | `Close] -> unit Lwt.t) -> t
+  val create: Tcpip.Tcp.Keepalive.t -> ([ `SendProbe | `Close] -> unit Lwt.t) -> t
   (** [create configuration f clock] returns a keep-alive timer which will call
       [f] in future depending on both the [configuration] and any calls to
       [refresh] *)

--- a/src/tcp/wire.ml
+++ b/src/tcp/wire.ml
@@ -20,11 +20,11 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let count_tcp_to_ip = MProf.Counter.make ~name:"tcp-to-ip"
 
-module Make (Ip:Mirage_protocols.IP) = struct
+module Make (Ip : Tcpip.Ip.S) = struct
 
-  type error = Mirage_protocols.Ip.error
+  type error = Tcpip.Ip.error
 
-  let pp_error = Mirage_protocols.Ip.pp_error
+  let pp_error = Tcpip.Ip.pp_error
 
   type t = {
     dst_port: int;             (* Remote TCP port *)

--- a/src/tcp/wire.mli
+++ b/src/tcp/wire.mli
@@ -14,9 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (Ip:Mirage_protocols.IP) : sig
+module Make (Ip : Tcpip.Ip.S) : sig
 
-  type error = Mirage_protocols.Ip.error
+  type error = Tcpip.Ip.error
   (** The type for TCP wire errors. *)
 
   val pp_error: error Fmt.t

--- a/src/tcpip_checksum/dune
+++ b/src/tcpip_checksum/dune
@@ -1,6 +1,6 @@
 (library
- (name tcpip)
- (public_name tcpip)
+ (name tcpip_checksum)
+ (public_name tcpip.checksum)
  (modules tcpip_checksum)
  (instrumentation
   (backend bisect_ppx))

--- a/src/tcpip_checksum/dune
+++ b/src/tcpip_checksum/dune
@@ -10,8 +10,3 @@
   (names checksum_stubs)
   (flags :standard))
  (wrapped false))
-
-(library
- (name tcpip_unix)
- (public_name tcpip.unix)
- (modules tcpip_unix))

--- a/src/udp/dune
+++ b/src/udp/dune
@@ -3,7 +3,7 @@
  (public_name tcpip.udp)
  (instrumentation
   (backend bisect_ppx))
- (libraries mirage-protocols mirage-random logs tcpip randomconv)
+ (libraries mirage-random logs tcpip randomconv tcpip.checksum)
  (preprocess
   (pps ppx_cstruct))
  (wrapped false))

--- a/src/udp/udp.ml
+++ b/src/udp/udp.ml
@@ -19,7 +19,7 @@ open Lwt.Infix
 let src = Logs.Src.create "udp" ~doc:"Mirage UDP"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(Ip: Mirage_protocols.IP)(Random:Mirage_random.S) = struct
+module Make (Ip : Tcpip.Ip.S) (Random : Mirage_random.S) = struct
 
   type ipaddr = Ip.ipaddr
   type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lwt.t

--- a/src/udp/udp.mli
+++ b/src/udp/udp.mli
@@ -14,9 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
-module Make (IP:Mirage_protocols.IP)(R:Mirage_random.S) : sig
-  include Mirage_protocols.UDP
-     with type ipaddr = IP.ipaddr
+module Make (IP : Tcpip.Ip.S) (R : Mirage_random.S) : sig
+  include Tcpip.Udp.S with type ipaddr = IP.ipaddr
   val connect : IP.t -> t Lwt.t
 end

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -33,8 +33,6 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}
@@ -46,14 +44,14 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
-  "mirage-flow" {with-test & >= "2.0.0"}
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}
-  "arp" {with-test & >= "2.3.0"}
   "ipaddr-cstruct" {with-test}
   "lru" {>= "0.3.0"}
   "metrics"

--- a/test/dune
+++ b/test/dune
@@ -2,9 +2,9 @@
  (name test)
  (libraries alcotest mirage-random-test lwt.unix logs logs.fmt mirage-profile
    mirage-flow mirage-vnetif mirage-clock-unix pcap-format duration
-   mirage-random mirage-protocols mirage-stack arp arp.mirage ethernet
-   tcpip.ipv4 tcpip.tcp tcpip.udp tcpip.stack-direct tcpip.icmpv4
-   tcpip.udpv4-socket tcpip.tcpv4-socket tcpip.icmpv4-socket
-   tcpip.stack-socket tcpip.ipv6 ipaddr-cstruct macaddr-cstruct tcpip)
+   mirage-random arp arp.mirage ethernet tcpip.ipv4 tcpip.tcp tcpip.udp
+   tcpip.stack-direct tcpip.icmpv4 tcpip.udpv4-socket tcpip.tcpv4-socket
+   tcpip.icmpv4-socket tcpip.stack-socket tcpip.ipv6 ipaddr-cstruct
+   macaddr-cstruct tcpip)
  (action
   (run %{test} -q -e --color=always)))

--- a/test/static_arp.ml
+++ b/test/static_arp.ml
@@ -1,17 +1,17 @@
 open Lwt.Infix
 
-module Make(E : Mirage_protocols.ETHERNET)(Time : Mirage_time.S) = struct
+module Make(E : Ethernet.S)(Time : Mirage_time.S) = struct
   module A = Arp.Make(E)(Time)
   (* generally repurpose A, but substitute input and query, and add functions
      for adding/deleting entries *)
-  type error = Mirage_protocols.Arp.error
+  type error = A.error
 
   type t = {
     base : A.t;
     table : (Ipaddr.V4.t, Macaddr.t) Hashtbl.t;
   }
 
-  let pp_error = Mirage_protocols.Arp.pp_error
+  let pp_error = A.pp_error
   let add_ip t = A.add_ip t.base
   let remove_ip t = A.remove_ip t.base
   let set_ips t = A.set_ips t.base

--- a/test/test_icmpv4.ml
+++ b/test/test_icmpv4.ml
@@ -15,7 +15,7 @@ type decomposed = {
   ipv4_payload : Cstruct.t;
   ipv4_header : Ipv4_packet.t;
   ethernet_payload : Cstruct.t;
-  ethernet_header : Ethernet_packet.t;
+  ethernet_header : Ethernet.Packet.t;
 }
 
 module Ip = Static_ipv4.Make(Mirage_random_test)(Mclock)(E)(Static_arp)
@@ -43,7 +43,7 @@ let (>>=?) = testbind
 let listener_address = Ipaddr.V4.of_string_exn "192.168.222.1"
 let speaker_address = Ipaddr.V4.of_string_exn "192.168.222.10"
 
-let header_size = Ethernet_wire.sizeof_ethernet
+let header_size = Ethernet.Packet.sizeof_ethernet
 
 let get_stack ?(backend = B.create ~use_async_readers:true
                   ~yield:(fun() -> Lwt.pause ()) ())
@@ -153,8 +153,8 @@ let echo_silent () =
 
 let write_errors () =
   let decompose buf =
-    let open Ethernet_packet in
-    let* ethernet_header, ethernet_payload = Unmarshal.of_cstruct buf in
+    let open Ethernet.Packet in
+    let* ethernet_header, ethernet_payload = of_cstruct buf in
     match ethernet_header.ethertype with
     | `IPv6 | `ARP -> Error "not an ipv4 packet"
     | `IPv4 ->

--- a/test/test_ipv6.ml
+++ b/test/test_ipv6.ml
@@ -35,7 +35,7 @@ let get_stack backend address =
 let noop = fun ~src:_ ~dst:_ _ -> Lwt.return_unit
 
 let listen ?(tcp = noop) ?(udp = noop) ?(default = noop) stack =
-  V.listen stack.netif ~header_size:Ethernet_wire.sizeof_ethernet
+  V.listen stack.netif ~header_size:Ethernet.Packet.sizeof_ethernet
     ( E.input stack.ethif
       ~arpv4:(fun _ -> Lwt.return_unit)
       ~ipv4:(fun _ -> Lwt.return_unit)
@@ -85,7 +85,7 @@ let create_ethernet backend =
   V.connect backend >>= fun netif ->
   E.connect netif >|= fun ethif ->
   (fun ipv6 ->
-     V.listen netif ~header_size:Ethernet_wire.sizeof_ethernet
+     V.listen netif ~header_size:Ethernet.Packet.sizeof_ethernet
        (E.input ethif
           ~arpv4:(fun _ -> Lwt.return_unit)
           ~ipv4:(fun _ -> Lwt.return_unit)

--- a/test/test_rfc5961.ml
+++ b/test/test_rfc5961.ml
@@ -40,7 +40,7 @@ let server_ip = Ipaddr.V4.of_string_exn "10.0.0.100"
 let server_cidr = Ipaddr.V4.Prefix.make 24 server_ip
 let gateway = Ipaddr.V4.of_string_exn "10.0.0.1"
 
-let header_size = Ethernet_wire.sizeof_ethernet
+let header_size = Ethernet.Packet.sizeof_ethernet
 
 (* defaults when injecting packets *)
 let options = []

--- a/test/vnetif_backends.ml
+++ b/test/vnetif_backends.ml
@@ -56,14 +56,14 @@ module Frame_size_enforced = struct
       X.write t.xt id ~size fill
 
   let set_frame_size t m = t.frame_size <- m
-  let set_max_ip_mtu t m = t.frame_size <- m + Ethernet_wire.sizeof_ethernet
+  let set_max_ip_mtu t m = t.frame_size <- m + Ethernet.Packet.sizeof_ethernet
 
   let create ~frame_size () =
     let xt = X.create ~use_async_readers:true ~yield:(fun() -> Lwt.pause () ) () in
     { xt ; frame_size }
 
   let create () =
-    create ~frame_size:(1500 + Ethernet_wire.sizeof_ethernet) ()
+    create ~frame_size:(1500 + Ethernet.Packet.sizeof_ethernet) ()
 
 end
 

--- a/test/vnetif_common.ml
+++ b/test/vnetif_common.ml
@@ -33,8 +33,8 @@ sig
   type buffer
   type 'a io
   type id
-  module Stackv4 : Mirage_stack.V4
-  module Stackv6 : Mirage_stack.V6
+  module Stackv4 : Tcpip.Stack.V4
+  module Stackv6 : Tcpip.Stack.V6
 
   (** Create a new backend *)
   val create_backend : unit -> backend


### PR DESCRIPTION
BREAKING: The tcpip library used to provide the checksum functionality -> this
 is now in the tcpip.checksum library (same module Tcpip_checksum)

The tcpip library now provides the module types for IP, UDP, TCP, and STACK

See https://github.com/mirage/mirage/issues/1255 for discussion