### PR TITLE
stack-unix: use custom switched_off values for udp & tcp socket stacks

### DIFF
--- a/src/stack-unix/tcpip_stack_socket.ml
+++ b/src/stack-unix/tcpip_stack_socket.ml
@@ -46,8 +46,6 @@ module V4 = struct
   let connect udpv4 tcpv4 =
     Log.info (fun f -> f "IPv4 socket stack: connect");
     let switched_off, stop = Lwt.wait () in
-    TCPV4.set_switched_off tcpv4 switched_off;
-    UDPV4.set_switched_off udpv4 switched_off;
     Lwt.return { tcpv4; udpv4; stop; switched_off }
 
   let disconnect t =
@@ -83,8 +81,6 @@ module V6 = struct
   let connect udp tcp =
     Log.info (fun f -> f "IPv6 socket stack: connect");
     let switched_off, stop = Lwt.wait () in
-    UDP.set_switched_off udp switched_off;
-    TCP.set_switched_off tcp switched_off;
     Lwt.return { tcp; udp; stop; switched_off }
 
   let disconnect t =
@@ -120,8 +116,6 @@ module V4V6 = struct
   let connect udp tcp =
     Log.info (fun f -> f "Dual IPv4 and IPv6 socket stack: connect");
     let switched_off, stop = Lwt.wait () in
-    UDP.set_switched_off udp switched_off;
-    TCP.set_switched_off tcp switched_off;
     Lwt.return { tcp; udp; stop; switched_off }
 
   let disconnect t =

--- a/src/stack-unix/tcpv4_socket.ml
+++ b/src/stack-unix/tcpv4_socket.ml
@@ -26,7 +26,7 @@ type t = {
   interface: Unix.inet_addr;    (* source ip to bind to *)
   mutable active_connections : Lwt_unix.file_descr list;
   listen_sockets : (int, Lwt_unix.file_descr) Hashtbl.t;
-  mutable switched_off : unit Lwt.t;
+  switched_off : unit Lwt.t;
 }
 
 include Tcp_socket
@@ -36,11 +36,9 @@ let connect addr =
     interface = Ipaddr_unix.V4.to_inet_addr (Ipaddr.V4.Prefix.address addr);
     active_connections = [];
     listen_sockets = Hashtbl.create 7;
-    switched_off = Lwt.return_unit;
+    switched_off = fst (Lwt.wait ());
   } in
   Lwt.return t
-
-let set_switched_off t switched_off = t.switched_off <- switched_off
 
 let disconnect t =
   Lwt_list.iter_p close t.active_connections >>= fun () ->

--- a/src/stack-unix/tcpv4_socket.mli
+++ b/src/stack-unix/tcpv4_socket.mli
@@ -21,7 +21,3 @@ include Tcpip.Tcp.S
    and type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 val connect : Ipaddr.V4.Prefix.t -> t Lwt.t
-
-val disconnect : t -> unit Lwt.t
-
-val set_switched_off : t -> unit Lwt.t -> unit

--- a/src/stack-unix/tcpv4v6_socket.ml
+++ b/src/stack-unix/tcpv4v6_socket.ml
@@ -27,10 +27,8 @@ type t = {
   interface: [ `Any | `Ip of Unix.inet_addr * Unix.inet_addr | `V4_only of Unix.inet_addr | `V6_only of Unix.inet_addr ];    (* source ip to bind to *)
   mutable active_connections : Lwt_unix.file_descr list;
   listen_sockets : (int, Lwt_unix.file_descr list) Hashtbl.t;
-  mutable switched_off : unit Lwt.t;
+  switched_off : unit Lwt.t;
 }
-
-let set_switched_off t switched_off = t.switched_off <- switched_off
 
 let any_v6 = Ipaddr_unix.V6.to_inet_addr Ipaddr.V6.unspecified
 
@@ -57,7 +55,7 @@ let connect ~ipv4_only ~ipv6_only ipv4 ipv6 =
         else
           `Ip (v4_unix, Ipaddr_unix.V6.to_inet_addr v6)
   in
-  Lwt.return {interface; active_connections = []; listen_sockets = Hashtbl.create 7; switched_off = Lwt.return_unit}
+  Lwt.return {interface; active_connections = []; listen_sockets = Hashtbl.create 7; switched_off = fst (Lwt.wait ()) }
 
 let disconnect t =
   Lwt_list.iter_p close t.active_connections >>= fun () ->

--- a/src/stack-unix/tcpv4v6_socket.mli
+++ b/src/stack-unix/tcpv4v6_socket.mli
@@ -22,5 +22,3 @@ include Tcpip.Tcp.S
    and type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 val connect : ipv4_only:bool -> ipv6_only:bool -> Ipaddr.V4.Prefix.t -> Ipaddr.V6.Prefix.t option -> t Lwt.t
-
-val set_switched_off : t -> unit Lwt.t -> unit

--- a/src/stack-unix/tcpv6_socket.ml
+++ b/src/stack-unix/tcpv6_socket.ml
@@ -27,10 +27,8 @@ type t = {
   interface: Unix.inet_addr;    (* source ip to bind to *)
   mutable active_connections : Lwt_unix.file_descr list;
   listen_sockets : (int, Lwt_unix.file_descr) Hashtbl.t;
-  mutable switched_off : unit Lwt.t;
+  switched_off : unit Lwt.t;
 }
-
-let set_switched_off t switched_off = t.switched_off <- switched_off
 
 include Tcp_socket
 
@@ -44,7 +42,7 @@ let connect addr =
     interface = Ipaddr_unix.V6.to_inet_addr ip;
     active_connections = [];
     listen_sockets = Hashtbl.create 7;
-    switched_off = Lwt.return_unit
+    switched_off = fst (Lwt.wait ());
   }
 
 let disconnect t =

--- a/src/stack-unix/tcpv6_socket.mli
+++ b/src/stack-unix/tcpv6_socket.mli
@@ -22,7 +22,3 @@ include Tcpip.Tcp.S
    and type write_error = [ Tcpip.Tcp.write_error | `Exn of exn ]
 
 val connect : Ipaddr.V6.Prefix.t option -> t Lwt.t
-
-val disconnect : t -> unit Lwt.t
-
-val set_switched_off : t -> unit Lwt.t -> unit

--- a/src/stack-unix/udpv4_socket.ml
+++ b/src/stack-unix/udpv4_socket.ml
@@ -25,10 +25,8 @@ type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lw
 type t = {
   interface: Unix.inet_addr; (* source ip to bind to *)
   listen_fds: ((Unix.inet_addr * int),Lwt_unix.file_descr) Hashtbl.t; (* UDPv4 fds bound to a particular source ip/port *)
-  mutable switched_off: unit Lwt.t;
+  switched_off: unit Lwt.t;
 }
-
-let set_switched_off t switched_off = t.switched_off <- switched_off
 
 let ignore_canceled = function
   | Lwt.Canceled -> Lwt.return_unit
@@ -59,7 +57,7 @@ let connect ip =
   let t =
     let listen_fds = Hashtbl.create 7 in
     let interface = Ipaddr_unix.V4.to_inet_addr (Ipaddr.V4.Prefix.address ip) in
-    { interface; listen_fds; switched_off = Lwt.return_unit }
+    { interface; listen_fds; switched_off = fst (Lwt.wait ()) }
   in
   Lwt.return t
 

--- a/src/stack-unix/udpv4v6_socket.ml
+++ b/src/stack-unix/udpv4v6_socket.ml
@@ -28,10 +28,8 @@ let any_v6 = Ipaddr_unix.V6.to_inet_addr Ipaddr.V6.unspecified
 type t = {
   interface: [ `Any | `Ip of Unix.inet_addr * Unix.inet_addr | `V4_only of Unix.inet_addr | `V6_only of Unix.inet_addr ]; (* source ip to bind to *)
   listen_fds: (int, Lwt_unix.file_descr * Lwt_unix.file_descr option) Hashtbl.t; (* UDP fds bound to a particular port *)
-  mutable switched_off : unit Lwt.t;
+  switched_off : unit Lwt.t;
 }
-
-let set_switched_off t switched_off = t.switched_off <- switched_off
 
 let ignore_canceled = function
   | Lwt.Canceled -> Lwt.return_unit
@@ -117,7 +115,7 @@ let connect ~ipv4_only ~ipv6_only ipv4 ipv6 =
           `Ip (v4_unix, Ipaddr_unix.V6.to_inet_addr v6)
   in
   let listen_fds = Hashtbl.create 7 in
-  Lwt.return { interface; listen_fds; switched_off = Lwt.return_unit }
+  Lwt.return { interface; listen_fds; switched_off = fst (Lwt.wait ()) }
 
 let disconnect t =
   Hashtbl.fold (fun _ (fd, fd') r ->

--- a/src/stack-unix/udpv6_socket.ml
+++ b/src/stack-unix/udpv6_socket.ml
@@ -26,10 +26,8 @@ type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lw
 type t = {
   interface: Unix.inet_addr; (* source ip to bind to *)
   listen_fds: ((Unix.inet_addr * int),Lwt_unix.file_descr) Hashtbl.t; (* UDPv6 fds bound to a particular source ip/port *)
-  mutable switched_off : unit Lwt.t;
+  switched_off : unit Lwt.t;
 }
-
-let set_switched_off t switched_off = t.switched_off <- switched_off
 
 let ignore_canceled = function
   | Lwt.Canceled -> Lwt.return_unit
@@ -65,7 +63,7 @@ let connect id =
       | None -> Ipaddr_unix.V6.to_inet_addr Ipaddr.V6.unspecified
       | Some ip -> Ipaddr_unix.V6.to_inet_addr (Ipaddr.V6.Prefix.address ip)
     in
-    { interface; listen_fds; switched_off = Lwt.return_unit }
+    { interface; listen_fds; switched_off = fst (Lwt.wait ()) }
   in
   Lwt.return t
 


### PR DESCRIPTION
this improves #457 and fixes #464