### PR TITLE
Use setup-ocaml GitHub Action and fix Windows build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Main workflow
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+        ocaml-compiler:
+          - 4.13.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune runtest

--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -1,5 +1,13 @@
-ifneq (, $(shell command -v opam))
-	PKG_CONFIG_PATH ?= $(shell opam var prefix)/lib/pkgconfig
+ifneq (, $(shell command -v opam || which opam))
+  ifeq ($(origin PKG_CONFIG_PATH), undefined)
+    PKG_CONFIG_PATH := $(shell opam var prefix)/lib/pkgconfig
+  endif
+endif
+
+ifeq ($(OS), Windows_NT)
+  ifneq (, $(shell command -v cygpath || which cygpath))
+    PKG_CONFIG_PATH := $(shell cygpath --unix --path "$(PKG_CONFIG_PATH)")
+  endif
 endif
 
 EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)

--- a/test/test.ml
+++ b/test/test.ml
@@ -26,7 +26,7 @@ let suite = [
   "rfc5961"        , Test_rfc5961.suite     ;
   "socket"         , Test_socket.suite      ;
   "connect"        , Test_connect.suite     ;
-  "connect_ipv6"        , Test_connect_ipv6.suite     ;
+  "connect_ipv6"   , Test_connect_ipv6.suite     ;
   "deadlock"       , Test_deadlock.suite    ;
   "iperf"          , Test_iperf.suite       ;
   "iperf_ipv6"     , Test_iperf_ipv6.suite       ;
@@ -51,4 +51,17 @@ let () =
       n, List.map (fun (d, s, f) -> d, s, run f) s
     ) suite
   in
-  Alcotest.run "tcpip" suite
+  let filter ~name ~index =
+    (* Lwt_bytes (as of 5.5.0) on Windows doesn't support UDP. *)
+    let skip = [
+        3 (* no_leak_fds_in_udpv4 *);
+        5 (* no_leak_fds_in_udpv6 *);
+        7 (* no_leak_fds_in_udpv4v6 *);
+        9 (* no_leak_fds_in_udpv4v6_2 *);
+        11 (* no_leak_fds_in_udpv4v6_3 *);
+        13 (* no_leak_fds_in_udpv4v6_4 *);
+        15 (* no_leak_fds_in_udpv4v6_5 *);
+      ] in
+    if Sys.win32 && name = "socket" && List.mem index skip then `Skip else `Run
+  in
+  Alcotest.run "tcpip" suite ~filter


### PR DESCRIPTION
mirage-tcpip requires the same fix than checkseum.
See the result of the CI [here](https://github.com/MisterDA/mirage-tcpip/runs/46937406520).