### PR TITLE
Be able to extract via functor/functoria the TCP/IP stack (regardless the UDP/IP stack)

### DIFF
--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -399,3 +399,15 @@ module MakeV4V6
     (match t.task with None -> () | Some task -> Lwt.cancel task);
     Lwt.return_unit
 end
+
+module TCPV4V6 (S : Tcpip.Stack.V4V6) : sig
+  include Tcpip.Tcp.S with type ipaddr = Ipaddr.t
+                       and type flow = S.TCP.flow
+                       and type t = S.TCP.t
+
+  val connect : S.t -> t Lwt.t
+end = struct
+  include S.TCP
+
+  let connect stackv4v6 = Lwt.return (S.tcp stackv4v6)
+end

--- a/src/stack-direct/tcpip_stack_direct.mli
+++ b/src/stack-direct/tcpip_stack_direct.mli
@@ -87,3 +87,15 @@ module MakeV4V6
       functioning, so that if the user wishes to establish outbound connections,
       they will be able to do so. *)
 end
+
+module TCPV4V6
+  (S : Tcpip.Stack.V4V6)
+  : sig
+  include Tcpip.Tcp.S with type ipaddr = Ipaddr.t
+                       and type flow = S.TCP.flow
+                       and type t = S.TCP.t
+
+  val connect : S.t -> t Lwt.t
+  (** [connect] returns the TCP/IP stack from a network stack to let the user to
+      initiate only TCP/IP connections (regardless UDP/IP). *)
+end


### PR DESCRIPTION
Some protocols need only the TCP/IP stack regardless the UDP/IP stack - and expects on their _functors_ a `Tcpip.Tcp.S`. It will be nice to have a standalone way to create such module and play then with `functoria` to pass it to these _functors_. It ensures by this way that these implementations will not send/recv UDP packets.