### PR TITLE
Work with MSVC compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Pending
+
+* Work with MSVC compiler (@jonahbeckford, #476)
+
 ### v7.0.1 (2021-12-17)
 
 * Fix cancellation of Unix socket when we don't use `Stack.connect` (@dinosaure, @hannesm, #466)

--- a/src/stack-unix/tcp_socket_options_stubs.c
+++ b/src/stack-unix/tcp_socket_options_stubs.c
@@ -22,7 +22,11 @@
 #include <caml/bigarray.h>
 #include <caml/unixsupport.h>
 
-#ifdef WIN32
+#ifdef _WIN32
+#ifdef _MSC_VER
+/* https://docs.microsoft.com/en-us/windows/win32/winsock/sio-keepalive-vals */
+#include <Mstcpip.h>
+#endif
 #else
 #include <sys/time.h>
 #include <sys/types.h>
@@ -38,7 +42,7 @@ CAMLprim value
 caml_tcp_set_keepalive_params(value v_fd, value v_time, value v_interval, value v_probe)
 {
   CAMLparam4(v_fd, v_time, v_interval, v_probe);
-#ifdef WIN32
+#ifdef _WIN32
   SOCKET s = Socket_val(v_fd);
   DWORD dwBytesRet=0;
   struct tcp_keepalive alive;

--- a/src/tcpip_checksum/checksum_stubs.c
+++ b/src/tcpip_checksum/checksum_stubs.c
@@ -300,7 +300,7 @@ mirage_tcpip_ones_complement_checksum_list(value v_cstruct_list)
     v_ofs = Field(v_hd, 1);
     v_len = Field(v_hd, 2);
     a = Caml_ba_array_val(v_ba);
-    addr = a->data + Int_val(v_ofs);
+    addr = (unsigned char *) (a->data) + Int_val(v_ofs);
     count = Int_val(v_len);
     if (count <= 0) continue;
     if (overflow != 0) {


### PR DESCRIPTION
This PR does two changes:

1. As in other mirage packages, changed `WIN32` macro to `_WIN32` (more below)
2. Cast a `void *` to `char *`  to get past compiler error `checksum_stubs.c(303): error C2036: 'void *': unknown size`

---

According to https://reviews.llvm.org/D40285 the `_WIN32` macro works across MSVC, GCC and clang compilers:

> In MSVC, WIN32 and WIN64 are never defined by the compiler, neither by system headers. Project files created by the IDE often contains them set manually though.
>
> GCC on the other hand predefines both `_WIN32` and `WIN32` (and similarly for -64), but only when using the GNU standards additions (which are enabled by default) `x86_64-w64-mingw32-gcc -E -dM - < /dev/null | grep WIN32` does include both, while the unprefixed one vanishes if you add e.g. `-std=c99` (but are still included if you set `-std=gnu99`).
>
> clang on the other hand doesn't check the standards version, but provides both `WIN32` and `_WIN32`. And for the really inconsistent case, with `clang -target x86_64-w64-mingw32 -E -dM - < /dev/null`, you will have `WIN64`, `_WIN64` and `_WIN32`, but no unprefixed `WIN32`.

So `WIN32` is incorrect, even on GCC compilers.

The `_WIN32` macro is documented at https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170