### PR TITLE
Use the last version of mirage-vnetif

### DIFF
--- a/tcpip.opam
+++ b/tcpip.opam
@@ -70,3 +70,6 @@ system](https://mirage.io). It provides implementations for the following module
 * UDP
 * TCP
 """
+pin-depends: [
+  [ "mirage-vnetif.dev" "git+https://github.com/mirage/mirage-vnetif.git#393bcc1ee16b5a1871a2ce71075551e0e651c5c9" ]
+]

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "2.0.0"}
-  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "mirage-vnetif" {with-test & >= "0.6.0"}
   "alcotest" {with-test & >="0.7.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
@@ -71,5 +71,5 @@ system](https://mirage.io). It provides implementations for the following module
 * TCP
 """
 pin-depends: [
-  [ "mirage-vnetif.dev" "git+https://github.com/mirage/mirage-vnetif.git#393bcc1ee16b5a1871a2ce71075551e0e651c5c9" ]
+  [ "mirage-vnetif.0.6.0" "git+https://github.com/mirage/mirage-vnetif.git#393bcc1ee16b5a1871a2ce71075551e0e651c5c9" ]
 ]


### PR DESCRIPTION
/cc @MagnusS It seems that we have a bug with the current `~master` version of `vnetif`:
```
┌──────────────────────────────────────────────────────────────────────────────┐
│ [FAIL]        icmpv4                3   error messages are written.          │
└──────────────────────────────────────────────────────────────────────────────┘
test.exe: [INFO] Connected Ethernet interface 02:50:00:00:00:01
test.exe: [INFO] Sending gratuitous ARP for 192.168.222.10 (02:50:00:00:00:01)
test.exe: [INFO] UDP interface connected on 192.168.222.10
test.exe: [INFO] Connected Ethernet interface 02:50:00:00:00:02
test.exe: [INFO] Sending gratuitous ARP for 192.168.222.1 (02:50:00:00:00:02)
test.exe: [INFO] UDP interface connected on 192.168.222.1
test.exe: [DEBUG] ip write: mtu is 1500, hdr_len is 20, size 8 payload len 4, needed_bytes 32
test.exe: [DEBUG] ip write: mtu is 1500, hdr_len is 20, size 0 payload len 40, needed_bytes 60
ASSERT ICMP message type
ASSERT ICMP message code
ASSERT Payload first byte
test.exe: [INFO] NUD: fc00::23 --> PROBE
test.exe: [DEBUG] ND6: Sending NS src=fc00::45 dst=fc00::23 tgt=fc00::23
test.exe: [DEBUG] IP6: Sending packet: dst=fc00::23 mac=02:50:00:00:00:01
test.exe: [DEBUG] ND: Received NS: src=fc00::45 dst=fc00::23 tgt=fc00::23
test.exe: [DEBUG] ND6: Sending NA: src=fc00::23 dst=fc00::45 tgt=fc00::23 sol=true
test.exe: [DEBUG] IP6: Sending packet: dst=fc00::45 mac=02:50:00:00:00:02
test.exe: [DEBUG] ND: Received NA: src=fc00::23 dst=fc00::45 tgt=fc00::23
test.exe: [INFO] NUD: fc00::23 --> REACHABLE
ASSERT writing thread completed first
FAIL writing thread completed first
Raised at Alcotest_engine__Test.check_err in file "src/alcotest-engine/test.ml", line 157, characters 20-48
Called from Lwt.Sequential_composition.bind.create_result_promise_and_callback_if_deferred.callback in file "src/core/lwt.ml", line 1860, characters 23-26
Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3068, characters 20-29
Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 31, characters 10-20
Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 118, characters 8-13
Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 124, characters 4-13
Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 180, characters 17-23
Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
``