### PR TITLE
Namespace tcp log sources

### DIFF
--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -17,7 +17,7 @@
 
 open Lwt.Infix
 
-let src = Logs.Src.create "pcb" ~doc:"Mirage TCP PCB module"
+let src = Logs.Src.create "tcp.pcb" ~doc:"Mirage TCP PCB module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make(Ip: Tcpip.Ip.S)(Time:Mirage_time.S)(Clock:Mirage_clock.MCLOCK)(Random:Mirage_random.S) =

--- a/src/tcp/segment.ml
+++ b/src/tcp/segment.ml
@@ -18,7 +18,7 @@
 
 open Lwt.Infix
 
-let src = Logs.Src.create "segment" ~doc:"Mirage TCP Segment module"
+let src = Logs.Src.create "tcp.segment" ~doc:"Mirage TCP Segment module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let lwt_sequence_add_l s seq =

--- a/src/tcp/state.ml
+++ b/src/tcp/state.ml
@@ -16,7 +16,7 @@
 
 open Lwt.Infix
 
-let src = Logs.Src.create "state" ~doc:"Mirage TCP State module"
+let src = Logs.Src.create "tcp.state" ~doc:"Mirage TCP State module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 type action =

--- a/src/tcp/tcptimer.ml
+++ b/src/tcp/tcptimer.ml
@@ -16,7 +16,7 @@
 
 open Lwt.Infix
 
-let src = Logs.Src.create "tcptimer" ~doc:"Mirage TCP Tcptimer module"
+let src = Logs.Src.create "tcp.tcptimer" ~doc:"Mirage TCP Tcptimer module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 type time = int64

--- a/src/tcp/window.ml
+++ b/src/tcp/window.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let src = Logs.Src.create "window" ~doc:"Mirage TCP Window module"
+let src = Logs.Src.create "tcp.window" ~doc:"Mirage TCP Window module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 type time = int64

--- a/src/tcp/wire.ml
+++ b/src/tcp/wire.ml
@@ -15,7 +15,7 @@
  *)
 open Lwt.Infix
 
-let src = Logs.Src.create "Wire" ~doc:"Mirage TCP Wire module"
+let src = Logs.Src.create "tcp.Wire" ~doc:"Mirage TCP Wire module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let count_tcp_to_ip = MProf.Counter.make ~name:"tcp-to-ip"

--- a/src/tcp/wire.ml
+++ b/src/tcp/wire.ml
@@ -15,7 +15,7 @@
  *)
 open Lwt.Infix
 
-let src = Logs.Src.create "tcp.Wire" ~doc:"Mirage TCP Wire module"
+let src = Logs.Src.create "tcp.wire" ~doc:"Mirage TCP Wire module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let count_tcp_to_ip = MProf.Counter.make ~name:"tcp-to-ip"


### PR DESCRIPTION
This adds a `tcp.` prefix to all tcp log sources. This makes it more clear where the log source is coming from (e.g. `state` could be many things).

An additional change I consider making is to make `tcp.Wire` all lower-case as in the other log sources.