### PR TITLE
TCP: don't hardcode a maximum write of 4000 bytes

### DIFF
--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -585,9 +585,7 @@ struct
 
   (* Maximum allowed write *)
   let write_available pcb =
-    (* Our effective outgoing MTU is what can fit in a page *)
-    min 4000 (min (Window.tx_mss pcb.wnd)
-                (Int32.to_int (UTX.available pcb.utx)))
+    min (Window.tx_mss pcb.wnd) (Int32.to_int (UTX.available pcb.utx))
 
   (* Wait for more write space *)
   let write_wait_for pcb sz =


### PR DESCRIPTION
This allows larger MTUs to be used, which helps when there is large per-packet overhead. For example

- qemu when using the socket network device
- Apple virtualization.framework's [VZFileHandleNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzfilehandlenetworkdeviceattachment?language=objc)

both expose ethernet frames over SOCK_DGRAM file descriptors, which leads to one syscall per frame.

There doesn't seem to be any assumption that the MTU must fit inside a 4096 byte page, so remove the `min`.

Signed-off-by: David Scott <dave@recoil.org>