### PR TITLE
TCP: avoid stall with larger MSS

### DIFF
--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -20,6 +20,9 @@ open Lwt.Infix
 let src = Logs.Src.create "tcp.pcb" ~doc:"Mirage TCP PCB module"
 module Log = (val Logs.src_log src : Logs.LOG)
 
+(* MSS options are 16 bites, so the max value is 64k *)
+let max_mss = Int32.of_int (64 * 1024)
+
 module Make(Ip: Tcpip.Ip.S)(Time:Mirage_time.S)(Clock:Mirage_clock.MCLOCK)(Random:Mirage_random.S) =
 struct
 
@@ -360,8 +363,9 @@ struct
     in
     (* Set up ACK module *)
     let ack = ACK.t ~send_ack ~last:(Sequence.succ rx_isn) in
-    (* The user application transmit buffer *)
-    let utx = UTX.create ~wnd ~txq ~max_size:16384l in
+    (* The user application transmit buffer. Ensure we are always allowed to write
+       an MSS of data into it before `available` returns 0. *)
+    let utx = UTX.create ~wnd ~txq ~max_size:(Int32.mul 2l max_mss) in
     let rxq = RXS.create ~rx_data ~ack ~wnd ~state ~tx_ack in
     (* Set up the keepalive state if requested *)
     let keepalive = match keepalive with


### PR DESCRIPTION
(I'm not an expert on this so I might have misunderstood something!)

If the connection requests a large MSS > 16k, for example to exploit a large MTU, then writes block because available space is believed to be 0.

Consider UTX.available:
```
let available t =
    let a = Int32.sub t.max_size t.bufbytes in
    match a < (Int32.of_int (Window.tx_mss t.wnd)) with
    | true -> 0l
    | false -> a
```
Initially max_size = 16k (hardcoded in flow.ml) and bufbytes = 0, so a = 16k (meaning 16k space is free in the buffer).

If the free space (a) is less than an MSS, we return 0 and the connection stalls.

I think the assumption is that the UTX can buffer at least an MSS worth of data so that when the free space (a) is less than an MSS, the buffer already contains an MSS worth of data to transmit to make progress (does this make sense? Or does it only need to contain 1 byte, so it could be MSS + 1?)

Bump the user buffer size to 128k which is 2x a 64k MSS (where 64k is the max value of the 16-bit MSS option). (Does this need to be configurable somewhere? Linux has `ip route add 192.168.1.0/24 dev eth0 advmss 65536` and socket options.)

My hope is that for https://github.com/moby/vpnkit which will use a `SOCK_DGRAM` interface to `send` and `recv` ethernet frames via Apple virtualization.framework and qemu, I'll be able to bump the ethernet MTU and TCP MSS to 64k to reduce the number of packets, since there's a syscall overhead per-packet.

I'm not completely sure this change is correct and I've not got a 64k MTU/MSS working end-to-end yet. I thought it was worth making the PR for discussion.

This might need rethinking if we support segmentation offload because we might see segments >> MTUs.

Signed-off-by: David Scott <dave@recoil.org>