### PR TITLE
TCP: Add ID for PCB to better track connections

### DIFF
--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -318,7 +318,7 @@ struct
 
   let emitted_keepalive_warning = ref false
 
-  let pcb_id = ref 0
+  let pcb_id = ref (-1)
 
   let new_pcb t params id keepalive =
     let mtu_mss = Ip.mtu t.ip ~dst:(WIRE.dst id) - Tcp_wire.sizeof_tcp in

--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -318,6 +318,8 @@ struct
 
   let emitted_keepalive_warning = ref false
 
+  let pcb_id = ref 0
+
   let new_pcb t params id keepalive =
     let mtu_mss = Ip.mtu t.ip ~dst:(WIRE.dst id) - Tcp_wire.sizeof_tcp in
     let { tx_wnd; sequence; options; tx_isn; rx_wnd; rx_wnd_scaleoffer } =
@@ -354,7 +356,10 @@ struct
     let tx_wnd_update = MProf.Trace.named_mvar_empty "tx_wnd_update" in
     (* Set up transmit and receive queues *)
     let on_close () = clearpcb t id tx_isn in
-    let state = State.t ~on_close in
+    let state =
+      incr pcb_id;
+      State.t ~id:!pcb_id ~on_close
+    in
     let txq, _tx_t =
       TXS.create ~xmit:(Tx.xmit_pcb t.ip id) ~wnd ~state ~rx_ack ~tx_ack ~tx_wnd_update
     in

--- a/src/tcp/state.ml
+++ b/src/tcp/state.ml
@@ -50,11 +50,12 @@ type close_cb = unit -> unit
 
 type t = {
   on_close: close_cb;
+  id: int;
   mutable state: tcpstate;
 }
 
-let t ~on_close =
-  { on_close; state=Closed }
+let t ~id ~on_close =
+  { on_close; id; state=Closed }
 
 let state t = t.state
 
@@ -170,7 +171,7 @@ module Make(Time:Mirage_time.S) = struct
     in
     let old_state = t.state in
     let new_state = tstr t.state i in
-    Log.debug (fun fmt -> fmt "%a  - %a -> %a"
+    Log.debug (fun fmt -> fmt "%d %a  - %a -> %a" t.id
           pp_tcpstate old_state pp_action i pp_tcpstate new_state);
     t.state <- new_state;
 

--- a/src/tcp/state.mli
+++ b/src/tcp/state.mli
@@ -50,7 +50,7 @@ type close_cb = unit -> unit
 type t
 
 val state : t -> tcpstate
-val t : on_close:close_cb -> t
+val t : id:int -> on_close:close_cb -> t
 
 val pp: Format.formatter -> t -> unit
 


### PR DESCRIPTION
As I'm investigating a connection leak, I found it useful to annotate state transitions with an unique ID per connection. 