### PR TITLE
remove ppx from mirage-tcpip

### DIFF
--- a/src/icmp/dune
+++ b/src/icmp/dune
@@ -4,6 +4,4 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries logs tcpip ipaddr tcpip.checksum)
- (preprocess
-  (pps ppx_cstruct))
  (wrapped false))

--- a/src/icmp/icmpv4.ml
+++ b/src/icmp/icmpv4.ml
@@ -48,7 +48,6 @@ module Make (IP : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t) = struct
           f "ICMP: error parsing message from %a: %s" Ipaddr.V4.pp src s);
       Lwt.return_unit
     | Ok (message, payload) ->
-      let open Icmpv4_wire in
       match message.ty, message.subheader with
       | Echo_reply, _ ->
         Log.info (fun f ->
@@ -65,7 +64,7 @@ module Make (IP : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t) = struct
         if t.echo_reply then begin
           let icmp = {
             code = 0x00;
-            ty   = Icmpv4_wire.Echo_reply;
+            ty   = Echo_reply;
             subheader = Id_and_seq (id, seq);
           } in
           writev t ~dst:src [ Marshal.make_cstruct icmp ~payload; payload ]
@@ -77,7 +76,7 @@ module Make (IP : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t) = struct
       | ty, _ ->
         Log.info (fun f ->
             f "ICMP unknown ty %s from %a"
-              (ty_to_string ty) Ipaddr.V4.pp src);
+              (Icmpv4_wire.ty_to_string ty) Ipaddr.V4.pp src);
         Lwt.return_unit
 
 end

--- a/src/icmp/icmpv4_wire.ml
+++ b/src/icmp/icmpv4_wire.ml
@@ -1,32 +1,58 @@
-[%%cstruct
-  type icmpv4 = {
-    ty:   uint8_t;
-    code: uint8_t;
-    csum: uint16_t;
-    id:   uint16_t;
-    seq:  uint16_t;
-  } [@@big_endian]
-]
-
-[%%cenum
 type ty =
-  | Echo_reply [@id 0]
-  | Destination_unreachable [@id 3]
+  | Echo_reply
+  | Destination_unreachable
   | Source_quench
   | Redirect
-  | Echo_request [@id 8]
-  | Time_exceeded [@id 11]
+  | Echo_request
+  | Time_exceeded
   | Parameter_problem
   | Timestamp_request
   | Timestamp_reply
   | Information_request
   | Information_reply
-  [@@uint8_t]
-]
 
-[%%cenum
+let ty_to_string = function
+  | Echo_reply -> "echo reply"
+  | Destination_unreachable -> "destination unreachable"
+  | Source_quench -> "source quench"
+  | Redirect -> "redirect"
+  | Echo_request -> "echo request"
+  | Time_exceeded -> "time exceeded"
+  | Parameter_problem -> "parameter problem"
+  | Timestamp_request -> "timestamp request"
+  | Timestamp_reply -> "timestamp reply"
+  | Information_request -> "information request"
+  | Information_reply -> "information reply"
+
+let int_to_ty = function
+  | 0 -> Some Echo_reply
+  | 3 -> Some Destination_unreachable
+  | 4 -> Some Source_quench
+  | 5 -> Some Redirect
+  | 8 -> Some Echo_request
+  | 11 -> Some Time_exceeded
+  | 12 -> Some Parameter_problem
+  | 13 -> Some Timestamp_request
+  | 14 -> Some Timestamp_reply
+  | 15 -> Some Information_request
+  | 16 -> Some Information_reply
+  | _ -> None
+
+let ty_to_int = function
+  | Echo_reply -> 0
+  | Destination_unreachable -> 3
+  | Source_quench -> 4
+  | Redirect -> 5
+  | Echo_request -> 8
+  | Time_exceeded -> 11
+  | Parameter_problem -> 12
+  | Timestamp_request -> 13
+  | Timestamp_reply -> 14
+  | Information_request -> 15
+  | Information_reply -> 16
+
 type unreachable_reason =
-  | Network_unreachable [@id 0]
+  | Network_unreachable
   | Host_unreachable
   | Protocol_unreachable
   | Port_unreachable
@@ -41,6 +67,37 @@ type unreachable_reason =
   | TOS_host_unreachable
   | Communication_prohibited
   | Host_precedence_violation
-  | Precedence_insufficient [@id 15]
-  [@@uint8_t]
-]
+  | Precedence_insufficient
+
+let unreachable_reason_to_int = function
+  | Network_unreachable -> 0
+  | Host_unreachable -> 1
+  | Protocol_unreachable -> 2
+  | Port_unreachable -> 3
+  | Would_fragment -> 4
+  | Source_route_failed -> 5
+  | Destination_network_unknown -> 6
+  | Destination_host_unknown -> 7
+  | Source_host_isolated -> 8
+  | Destination_net_prohibited -> 9
+  | Destination_host_prohibited -> 10
+  | TOS_network_unreachable -> 11
+  | TOS_host_unreachable -> 12
+  | Communication_prohibited -> 13
+  | Host_precedence_violation -> 14
+  | Precedence_insufficient -> 15
+
+let sizeof_icmpv4 = 8
+
+let ty_off = 0
+let code_off = 1
+let csum_off = 2
+
+let get_ty buf = Cstruct.get_uint8 buf ty_off
+let set_ty buf value = Cstruct.set_uint8 buf ty_off value
+
+let get_code buf = Cstruct.get_uint8 buf code_off
+let set_code buf value = Cstruct.set_uint8 buf code_off value
+
+let get_checksum buf = Cstruct.BE.get_uint16 buf csum_off
+let set_checksum buf value = Cstruct.BE.set_uint16 buf csum_off value

--- a/src/icmp/icmpv4_wire.mli
+++ b/src/icmp/icmpv4_wire.mli
@@ -1,0 +1,47 @@
+type ty =
+  | Echo_reply
+  | Destination_unreachable
+  | Source_quench
+  | Redirect
+  | Echo_request
+  | Time_exceeded
+  | Parameter_problem
+  | Timestamp_request
+  | Timestamp_reply
+  | Information_request
+  | Information_reply
+
+val ty_to_string : ty -> string
+val int_to_ty : int -> ty option
+val ty_to_int : ty -> int
+
+type unreachable_reason =
+  | Network_unreachable
+  | Host_unreachable
+  | Protocol_unreachable
+  | Port_unreachable
+  | Would_fragment
+  | Source_route_failed
+  | Destination_network_unknown
+  | Destination_host_unknown
+  | Source_host_isolated
+  | Destination_net_prohibited
+  | Destination_host_prohibited
+  | TOS_network_unreachable
+  | TOS_host_unreachable
+  | Communication_prohibited
+  | Host_precedence_violation
+  | Precedence_insufficient
+
+val unreachable_reason_to_int : unreachable_reason -> int
+
+val sizeof_icmpv4 : int
+
+val get_ty : Cstruct.t -> int
+val set_ty : Cstruct.t -> int -> unit
+
+val get_code : Cstruct.t -> int
+val set_code : Cstruct.t -> int -> unit
+
+val get_checksum : Cstruct.t -> int
+val set_checksum : Cstruct.t -> int -> unit

--- a/src/ipv4/dune
+++ b/src/ipv4/dune
@@ -5,6 +5,4 @@
   (backend bisect_ppx))
  (libraries logs ipaddr cstruct tcpip tcpip.udp tcpip.checksum mirage-random
    mirage-clock randomconv lru arp.mirage ethernet)
- (preprocess
-  (pps ppx_cstruct))
  (wrapped false))

--- a/src/ipv4/fragments.ml
+++ b/src/ipv4/fragments.ml
@@ -196,7 +196,7 @@ let fragment ~mtu hdr payload =
       if more then Cstruct.split payload data_size else payload, Cstruct.empty
     in
     let payload_len = Cstruct.length this_payload in
-    Ipv4_wire.set_ipv4_csum hdr_buf 0;
+    Ipv4_wire.set_checksum hdr_buf 0;
     (match Ipv4_packet.Marshal.into_cstruct ~payload_len hdr' hdr_buf with
      (* hdr_buf is allocated with hdr_size (computed below) bytes, thus
         into_cstruct will never return an error! *)

--- a/src/ipv4/ipv4_common.ml
+++ b/src/ipv4/ipv4_common.ml
@@ -1,6 +1,0 @@
-let set_checksum buf =
-  let open Ipv4_wire in
-  (* Set the mutable values in the ipv4 header *)
-  set_ipv4_csum buf 0;
-  let checksum = Tcpip_checksum.ones_complement buf in
-  set_ipv4_csum buf checksum

--- a/src/ipv4/ipv4_wire.ml
+++ b/src/ipv4/ipv4_wire.ml
@@ -1,14 +1,39 @@
-[%%cstruct
-type ipv4 = {
-    hlen_version: uint8_t;
-    tos:          uint8_t;
-    len:          uint16_t;
-    id:           uint16_t;
-    off:          uint16_t;
-    ttl:          uint8_t;
-    proto:        uint8_t;
-    csum:         uint16_t;
-    src:          uint32_t;
-    dst:          uint32_t;
-  } [@@big_endian]
-]
+let sizeof_ipv4 = 20
+
+let hlen_version_off = 0
+let _tos_off = 1
+let len_off = 2
+let id_off = 4
+let off_off = 6
+let ttl_off = 8
+let proto_off = 9
+let csum_off = 10
+let src_off = 12
+let dst_off = 16
+
+let get_hlen_version buf = Cstruct.get_uint8 buf hlen_version_off
+let set_hlen_version buf v = Cstruct.set_uint8 buf hlen_version_off v
+
+let get_len buf = Cstruct.BE.get_uint16 buf len_off
+let set_len buf v = Cstruct.BE.set_uint16 buf len_off v
+
+let get_id buf = Cstruct.BE.get_uint16 buf id_off
+let set_id buf v = Cstruct.BE.set_uint16 buf id_off v
+
+let get_off buf = Cstruct.BE.get_uint16 buf off_off
+let set_off buf v = Cstruct.BE.set_uint16 buf off_off v
+
+let get_ttl buf = Cstruct.get_uint8 buf ttl_off
+let set_ttl buf v = Cstruct.set_uint8 buf ttl_off v
+
+let get_proto buf = Cstruct.get_uint8 buf proto_off
+let set_proto buf v = Cstruct.set_uint8 buf proto_off v
+
+let get_checksum buf = Cstruct.BE.get_uint16 buf csum_off
+let set_checksum buf value = Cstruct.BE.set_uint16 buf csum_off value
+
+let get_src buf = Ipaddr.V4.of_int32 (Cstruct.BE.get_uint32 buf src_off)
+let set_src buf v = Cstruct.BE.set_uint32 buf src_off (Ipaddr.V4.to_int32 v)
+
+let get_dst buf = Ipaddr.V4.of_int32 (Cstruct.BE.get_uint32 buf dst_off)
+let set_dst buf v = Cstruct.BE.set_uint32 buf dst_off (Ipaddr.V4.to_int32 v)

--- a/src/ipv4/ipv4_wire.mli
+++ b/src/ipv4/ipv4_wire.mli
@@ -1,0 +1,28 @@
+val sizeof_ipv4 : int
+
+val get_hlen_version : Cstruct.t -> int
+val set_hlen_version : Cstruct.t -> int -> unit
+
+val get_len : Cstruct.t -> int
+val set_len : Cstruct.t -> int -> unit
+
+val get_id : Cstruct.t -> int
+val set_id : Cstruct.t -> int -> unit
+
+val get_off : Cstruct.t -> int
+val set_off : Cstruct.t -> int -> unit
+
+val get_ttl : Cstruct.t -> int
+val set_ttl : Cstruct.t -> int -> unit
+
+val get_proto : Cstruct.t -> int
+val set_proto : Cstruct.t -> int -> unit
+
+val get_checksum : Cstruct.t -> int
+val set_checksum : Cstruct.t -> int -> unit
+
+val get_src : Cstruct.t -> Ipaddr.V4.t
+val set_src : Cstruct.t -> Ipaddr.V4.t -> unit
+
+val get_dst : Cstruct.t -> Ipaddr.V4.t
+val set_dst : Cstruct.t -> Ipaddr.V4.t -> unit

--- a/src/ipv6/dune
+++ b/src/ipv6/dune
@@ -5,7 +5,5 @@
   (backend bisect_ppx))
  (libraries logs mirage-time mirage-net macaddr-cstruct tcpip.checksum
    mirage-clock duration ipaddr cstruct mirage-random tcpip randomconv
-   ethernet)
- (preprocess
-  (pps ppx_cstruct))
+   ethernet ipaddr-cstruct)
  (wrapped false))

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -117,8 +117,8 @@ module Make (N : Mirage_net.S)
   let pseudoheader t ?src:source dst proto len =
     let ph = Cstruct.create (16 + 16 + 8) in
     let src = match source with None -> src t ~dst | Some x -> x in
-    Ndpv6.ipaddr_to_cstruct_raw src ph 0;
-    Ndpv6.ipaddr_to_cstruct_raw dst ph 16;
+    Ipv6_wire.set_ip ph 0 src;
+    Ipv6_wire.set_ip ph 16 dst;
     Cstruct.BE.set_uint32 ph 32 (Int32.of_int len);
     Cstruct.set_uint8 ph 36 0;
     Cstruct.set_uint8 ph 37 0;

--- a/src/ipv6/ipv6_wire.ml
+++ b/src/ipv6/ipv6_wire.ml
@@ -1,14 +1,4 @@
-
-[%%cstruct
-type ipv6 = {
-    version_flow: uint32_t;
-    len:          uint16_t;  (* payload length (includes extensions) *)
-    nhdr:         uint8_t; (* next header *)
-    hlim:         uint8_t; (* hop limit *)
-    src:          uint8_t [@len 16];
-    dst:          uint8_t [@len 16];
-  } [@@big_endian]
-]
+let sizeof_ipv6 = 40
 
 let int_to_protocol = function
   | 58  -> Some `ICMP
@@ -21,112 +11,197 @@ let protocol_to_int = function
   | `TCP    -> 6
   | `UDP    -> 17
 
-[%%cstruct
-type icmpv6 = {
-    ty:       uint8_t;
-    code:     uint8_t;
-    csum:     uint16_t;
-    reserved: uint32_t;
-  } [@@big_endian]
-]
+let set_ip buf off v =
+  Ipaddr_cstruct.V6.write_cstruct_exn v (Cstruct.shift buf off)
+let get_ip buf off =
+  Ipaddr_cstruct.V6.of_cstruct_exn (Cstruct.shift buf off)
 
-[%%cstruct
-type pingv6 = {
-    ty:   uint8_t;
-    code: uint8_t;
-    csum: uint16_t;
-    id:   uint16_t;
-    seq:  uint16_t;
-  } [@@big_endian]
-]
-[%%cstruct
-type ns = {
-    ty:       uint8_t;
-    code:     uint8_t;
-    csum:     uint16_t;
-    reserved: uint32_t;
-    target:   uint8_t  [@len 16];
-  } [@@big_endian]
-]
-[%%cstruct
-type na = {
-    ty: uint8_t;
-    code: uint8_t;
-    csum: uint16_t;
-    reserved: uint32_t;
-    target: uint8_t [@len 16];
-  } [@@big_endian]
-]
-let get_na_router buf =
-  (Cstruct.get_uint8 buf 4 land 0x80) <> 0
+let version_flow_off = 0
+let len_off = 4
+let nhdr_off = 6
+let hlim_off = 7
+let src_off = 8
+let dst_off = 24
 
-let get_na_solicited buf =
-  (Cstruct.get_uint8 buf 4 land 0x40) <> 0
+let get_version_flow buf = Cstruct.BE.get_uint32 buf version_flow_off
+let set_version_flow buf v = Cstruct.BE.set_uint32 buf version_flow_off v
 
-let get_na_override buf =
-  (Cstruct.get_uint8 buf 4 land 0x20) <> 0
+let get_nhdr buf = Cstruct.get_uint8 buf nhdr_off
+let set_nhdr buf v = Cstruct.set_uint8 buf nhdr_off v
 
-[%%cstruct
-type redirect = {
-    ty : uint8_t;
-    code : uint8_t;
-    csum : uint16_t;
-    reserved : uint32_t;
-    target : uint8_t [@len 16];
-    destination : uint8_t [@len 16];
-  } [@@big_endian]
-]
+let get_len buf = Cstruct.BE.get_uint16 buf len_off
+let set_len buf v = Cstruct.BE.set_uint16 buf len_off v
 
-[%%cstruct
-type rs = {
-    ty:       uint8_t;
-    code:     uint8_t;
-    csum:     uint16_t;
-    reserved: uint32_t;
-  } [@@big_endian]
-]
-[%%cstruct
-type opt_prefix = {
-    ty:                 uint8_t;
-    len:                uint8_t;
-    prefix_len:         uint8_t;
-    reserved1:          uint8_t;
-    valid_lifetime:     uint32_t;
-    preferred_lifetime: uint32_t;
-    reserved2:          uint32_t;
-    prefix:             uint8_t [@len 16];
-  } [@@big_endian]
-]
-let get_opt_prefix_on_link buf =
-  get_opt_prefix_reserved1 buf land 0x80 <> 0
+let get_hlim buf = Cstruct.get_uint8 buf hlim_off
+let set_hlim buf v = Cstruct.set_uint8 buf hlim_off v
 
-let get_opt_prefix_autonomous buf =
-  get_opt_prefix_reserved1 buf land 0x40 <> 0
+let get_src buf = get_ip buf src_off
+let set_src buf v = set_ip buf src_off v
 
-[%%cstruct
-type opt = {
-    ty:  uint8_t;
-    len: uint8_t;
-  } [@@big_endian]
-]
-[%%cstruct
-type llopt = {
-    ty:   uint8_t;
-    len:  uint8_t;
-    addr: uint8_t [@len 6];
-  } [@@big_endian]
-]
+let get_dst buf = get_ip buf dst_off
+let set_dst buf v = set_ip buf dst_off v
 
-[%%cstruct
-type ra = {
-    ty:              uint8_t;
-    code:            uint8_t;
-    csum:            uint16_t;
-    cur_hop_limit:   uint8_t;
-    reserved:        uint8_t;
-    router_lifetime: uint16_t;
-    reachable_time:  uint32_t;
-    retrans_timer:   uint32_t;
-  } [@@big_endian]
-]
-let sizeof_ipv6_pseudo_header = 16 + 16 + 4 + 4
+let ty_off = 0
+let get_ty buf = Cstruct.get_uint8 buf ty_off
+let set_ty buf v = Cstruct.set_uint8 buf ty_off v
+
+let code_off = 1
+let get_code buf = Cstruct.get_uint8 buf code_off
+let set_code buf v = Cstruct.set_uint8 buf code_off v
+
+module Ns = struct
+  let sizeof_ns = 24
+
+  let csum_off = 2
+  let reserved_off = 4
+  let target_off = 8
+
+  let get_checksum buf = Cstruct.BE.get_uint16 buf csum_off
+  let set_checksum buf v = Cstruct.BE.set_uint16 buf csum_off v
+  let get_reserved buf = Cstruct.BE.get_uint32 buf reserved_off
+  let set_reserved buf v = Cstruct.BE.set_uint32 buf reserved_off v
+  let get_target buf = get_ip buf target_off
+  let set_target buf v = set_ip buf target_off v
+end
+
+module Llopt = struct
+  let sizeof_llopt = 8
+
+  let len_off = 1
+  let addr_off = 2
+
+  let get_len buf = Cstruct.get_uint8 buf len_off
+  let set_len buf v = Cstruct.set_uint8 buf len_off v
+
+  let get_addr buf = Macaddr_cstruct.of_cstruct_exn (Cstruct.shift buf addr_off)
+  let set_addr buf v =
+    Macaddr_cstruct.write_cstruct_exn v (Cstruct.shift buf addr_off)
+end
+
+module Icmpv6 = struct
+  let sizeof_icmpv6 = 8
+
+  let _reserved_off = 4
+
+  let set_checksum = Ns.set_checksum
+end
+
+module Na = struct
+  let sizeof_na = 24
+
+  let get_reserved = Ns.get_reserved
+  let set_reserved = Ns.set_reserved
+  let get_target = Ns.get_target
+  let set_target = Ns.set_target
+
+  let get_first_reserved_byte buf =
+    Cstruct.get_uint8 buf Ns.reserved_off
+
+  let get_router buf = (get_first_reserved_byte buf land 0x80) <> 0
+  let get_solicited buf = (get_first_reserved_byte buf land 0x40) <> 0
+  let get_override buf = (get_first_reserved_byte buf land 0x20) <> 0
+end
+
+module Rs = struct
+  let sizeof_rs = 8
+
+  let set_checksum = Ns.set_checksum
+  let set_reserved = Ns.set_reserved
+end
+
+module Pingv6 = struct
+  let sizeof_pingv6 = 8
+
+  let id_off = 4
+  let seq_off = 6
+
+  let get_checksum = Ns.get_checksum
+  let set_checksum = Ns.set_checksum
+
+  let get_id buf = Cstruct.BE.get_uint16 buf id_off
+  let set_id buf v = Cstruct.BE.set_uint16 buf id_off v
+
+  let get_seq buf = Cstruct.BE.set_uint16 buf seq_off
+  let set_seq buf v = Cstruct.BE.set_uint16 buf seq_off v
+end
+
+module Opt = struct
+  let sizeof_opt = 2
+
+  let get_len = Llopt.get_len
+  let set_len = Llopt.set_len
+end
+
+module Opt_prefix = struct
+  let sizeof_opt_prefix = 32
+
+  let get_len = Llopt.get_len
+  let set_len = Llopt.set_len
+
+  let prefix_len_off = 2
+  let get_prefix_len buf = Cstruct.get_uint8 buf prefix_len_off
+  let set_prefix_len buf v = Cstruct.set_uint8 buf prefix_len_off v
+
+  let reserved1_off = 3
+  let get_reserved1 buf = Cstruct.get_uint8 buf reserved1_off
+  let set_reserved1 buf v = Cstruct.set_uint8 buf reserved1_off v
+
+  let valid_lifetime_off = 4
+  let get_valid_lifetime buf = Cstruct.BE.get_uint32 buf valid_lifetime_off
+  let set_valid_lifetime buf v = Cstruct.BE.set_uint32 buf valid_lifetime_off v
+
+  let preferred_lifetime_off = 8
+  let get_preferred_lifetime buf = Cstruct.BE.get_uint32 buf preferred_lifetime_off
+  let set_preferred_lifetime buf v = Cstruct.BE.set_uint32 buf preferred_lifetime_off v
+
+  let reserved2_off = 12
+
+  let prefix_off = 16
+  let get_prefix buf = get_ip buf prefix_off
+  let set_prefix buf v = set_ip buf prefix_off v
+
+  let on_link buf = get_reserved1 buf land 0x80 <> 0
+
+  let autonomous buf = get_reserved1 buf land 0x40 <> 0
+
+end
+
+module Ra = struct
+  let sizeof_ra = 16
+
+  let get_checksum = Ns.get_checksum
+  let set_checksum = Ns.set_checksum
+
+  let cur_hop_limit_off = 4
+  let get_cur_hop_limit buf = Cstruct.get_uint8 buf cur_hop_limit_off
+
+  let reserved_off = 5
+
+  let router_lifetime_off = 6
+  let get_router_lifetime buf = Cstruct.BE.get_uint16 buf router_lifetime_off
+
+  let reachable_time_off = 8
+  let get_reachable_time buf = Cstruct.BE.get_uint32 buf reachable_time_off
+
+  let retrans_timer_off = 12
+  let get_retrans_timer buf = Cstruct.BE.get_uint32 buf retrans_timer_off
+end
+
+module Redirect = struct
+  let sizeof_redirect = 40
+
+  let get_checksum = Ns.get_checksum
+  let set_checksum = Ns.set_checksum
+
+  let get_reserved = Ns.get_reserved
+  let set_reserved = Ns.set_reserved
+
+  let get_target = Ns.get_target
+  let set_target = Ns.set_target
+
+  let destination_off = 24
+  let get_destination buf = get_ip buf destination_off
+  let set_destination buf v = set_ip buf destination_off v
+end
+
+(* let sizeof_ipv6_pseudo_header = 16 + 16 + 4 + 4 *)

--- a/src/ipv6/ndpv6.mli
+++ b/src/ipv6/ndpv6.mli
@@ -19,8 +19,6 @@ type ipaddr = Ipaddr.V6.t
 type prefix = Ipaddr.V6.Prefix.t
 type time   = int64
 
-val ipaddr_of_cstruct : buffer -> ipaddr
-val ipaddr_to_cstruct_raw : ipaddr -> buffer -> int -> unit
 val checksum : buffer -> buffer list -> int
 
 type event =

--- a/src/stack-unix/icmpv4_socket.ml
+++ b/src/stack-unix/icmpv4_socket.ml
@@ -101,8 +101,8 @@ let listen t addr fn =
        probably reflects some kernel datastructure size rather than the real
        on-the-wire size. This confuses our IPv4 parser so we correct the size
        here. *)
-    let len = Ipv4_wire.get_ipv4_len receive_buffer in
-    Ipv4_wire.set_ipv4_len receive_buffer (min len (Cstruct.length receive_buffer));
+    let len = Ipv4_wire.get_len receive_buffer in
+    Ipv4_wire.set_len receive_buffer (min len (Cstruct.length receive_buffer));
     Lwt.async (fun () -> fn receive_buffer);
     loop ()
   in

--- a/src/tcp/dune
+++ b/src/tcp/dune
@@ -5,6 +5,4 @@
   (backend bisect_ppx))
  (libraries logs ipaddr cstruct lwt-dllist tcpip.checksum
    tcpip duration randomconv fmt mirage-time mirage-clock mirage-random
-   mirage-flow metrics)
- (preprocess
-  (pps ppx_cstruct)))
+   mirage-flow metrics))

--- a/src/tcp/tcp_wire.ml
+++ b/src/tcp/tcp_wire.ml
@@ -1,55 +1,67 @@
-[%%cstruct
-type tcp = {
-    src_port:   uint16_t;
-    dst_port:   uint16_t;
-    sequence:   uint32_t;
-    ack_number: uint32_t;
-    dataoff:    uint8_t;
-    flags:      uint8_t;
-    window:     uint16_t;
-    checksum:   uint16_t;
-    urg_ptr:    uint16_t;
-  } [@@big_endian]
-]
+let sizeof_tcp = 20
 
-[%%cstruct
-type tcpv4_pseudo_header = {
-    src:   uint32_t;
-    dst:   uint32_t;
-    res:   uint8_t;
-    proto: uint8_t;
-    len:   uint16_t;
-  } [@@big_endian]
-]
+let src_port_off = 0
+let dst_port_off = 2
+let sequence_off = 4
+let ack_off = 8
+let dataoff_off = 12
+let flags_off = 13
+let window_off = 14
+let checksum_off = 16
+let urg_ptr_off = 18
+
+let get_src_port buf = Cstruct.BE.get_uint16 buf src_port_off
+let set_src_port buf v = Cstruct.BE.set_uint16 buf src_port_off v
+
+let get_dst_port buf = Cstruct.BE.get_uint16 buf dst_port_off
+let set_dst_port buf v = Cstruct.BE.set_uint16 buf dst_port_off v
+
+let get_sequence buf = Cstruct.BE.get_uint32 buf sequence_off
+let set_sequence buf v = Cstruct.BE.set_uint32 buf sequence_off v
+
+let get_ack_number buf = Cstruct.BE.get_uint32 buf ack_off
+let set_ack_number buf v = Cstruct.BE.set_uint32 buf ack_off v
+
+let get_flags buf = Cstruct.get_uint8 buf flags_off
+let set_flags buf v = Cstruct.set_uint8 buf flags_off v
+
+let get_window buf = Cstruct.BE.get_uint16 buf window_off
+let set_window buf v = Cstruct.BE.set_uint16 buf window_off v
+
+let get_checksum buf = Cstruct.BE.get_uint16 buf checksum_off
+let set_checksum buf value = Cstruct.BE.set_uint16 buf checksum_off value
+
+let get_urg_ptr buf = Cstruct.BE.get_uint16 buf urg_ptr_off
+let set_urg_ptr buf value = Cstruct.BE.set_uint16 buf urg_ptr_off value
 
 (* XXX note that we overwrite the lower half of dataoff
  * with 0, so be careful when implemented CWE flag which
  * sits there *)
-let get_data_offset buf = ((get_tcp_dataoff buf) lsr 4) * 4
-let set_data_offset buf v = set_tcp_dataoff buf (v lsl 4)
+let get_data_offset buf = ((Cstruct.get_uint8 buf dataoff_off) lsr 4) * 4
+let set_data_offset buf v = Cstruct.set_uint8 buf dataoff_off (v lsl 4)
 
-let get_fin buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 0)) > 0
-let get_syn buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 1)) > 0
-let get_rst buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 2)) > 0
-let get_psh buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 3)) > 0
-let get_ack buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 4)) > 0
-let get_urg buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 5)) > 0
-let get_ece buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 6)) > 0
-let get_cwr buf = ((Cstruct.get_uint8 buf 13) land (1 lsl 7)) > 0
+let get_fin buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 0)) > 0
+let get_syn buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 1)) > 0
+let get_rst buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 2)) > 0
+let get_psh buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 3)) > 0
+let get_ack buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 4)) > 0
+let get_urg buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 5)) > 0
+let _get_ece buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 6)) > 0
+let _get_cwr buf = ((Cstruct.get_uint8 buf flags_off) land (1 lsl 7)) > 0
 
 let set_fin buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 0))
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 0))
 let set_syn buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 1))
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 1))
 let set_rst buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 2))
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 2))
 let set_psh buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 3))
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 3))
 let set_ack buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 4))
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 4))
 let set_urg buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 5))
-let set_ece buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 6))
-let set_cwr buf =
-  Cstruct.set_uint8 buf 13 ((Cstruct.get_uint8 buf 13) lor (1 lsl 7))
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 5))
+let _set_ece buf =
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 6))
+let _set_cwr buf =
+  Cstruct.set_uint8 buf flags_off ((Cstruct.get_uint8 buf flags_off) lor (1 lsl 7))

--- a/src/tcp/tcp_wire.mli
+++ b/src/tcp/tcp_wire.mli
@@ -1,0 +1,42 @@
+val sizeof_tcp : int
+
+val get_src_port : Cstruct.t -> int
+val set_src_port : Cstruct.t -> int -> unit
+
+val get_dst_port : Cstruct.t -> int
+val set_dst_port : Cstruct.t -> int -> unit
+
+val get_sequence : Cstruct.t -> int32
+val set_sequence : Cstruct.t -> int32 -> unit
+
+val get_ack_number : Cstruct.t -> int32
+val set_ack_number : Cstruct.t -> int32 -> unit
+
+val get_flags : Cstruct.t -> int
+val set_flags : Cstruct.t -> int -> unit
+
+val get_window : Cstruct.t -> int
+val set_window : Cstruct.t -> int -> unit
+
+val get_checksum : Cstruct.t -> int
+val set_checksum : Cstruct.t -> int -> unit
+
+val get_urg_ptr : Cstruct.t -> int
+val set_urg_ptr : Cstruct.t -> int -> unit
+
+val get_data_offset : Cstruct.t -> int
+val set_data_offset : Cstruct.t -> int -> unit
+
+val get_fin : Cstruct.t -> bool
+val get_syn : Cstruct.t -> bool
+val get_rst : Cstruct.t -> bool
+val get_psh : Cstruct.t -> bool
+val get_ack : Cstruct.t -> bool
+val get_urg : Cstruct.t -> bool
+
+val set_fin : Cstruct.t -> unit
+val set_syn : Cstruct.t -> unit
+val set_rst : Cstruct.t -> unit
+val set_psh : Cstruct.t -> unit
+val set_ack : Cstruct.t -> unit
+val set_urg : Cstruct.t -> unit

--- a/src/udp/dune
+++ b/src/udp/dune
@@ -4,6 +4,4 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries mirage-random logs tcpip randomconv tcpip.checksum)
- (preprocess
-  (pps ppx_cstruct))
  (wrapped false))

--- a/src/udp/udp_packet.mli
+++ b/src/udp/udp_packet.mli
@@ -8,7 +8,7 @@ val equal : t -> t -> bool
 
 module Unmarshal : sig
 
-  type error = string 
+  type error = string
 
 (** [of_cstruct buf] attempts to interpret [buf] as a UDP header.  If
     successful, it returns [Ok (header, payload)], although [payload] may be an

--- a/src/udp/udp_wire.ml
+++ b/src/udp/udp_wire.ml
@@ -1,9 +1,18 @@
-[%%cstruct
-type udp = {
-    source_port: uint16_t;
-    dest_port: uint16_t;
-    length: uint16_t;
-    checksum: uint16_t;
-  } [@@big_endian]
-]
+let sizeof_udp = 8
 
+let src_port_offset = 0
+let dst_port_offset = 2
+let length_offset = 4
+let checksum_offset = 6
+
+let get_src_port buf = Cstruct.BE.get_uint16 buf src_port_offset
+let set_src_port buf v = Cstruct.BE.set_uint16 buf src_port_offset v
+
+let get_dst_port buf = Cstruct.BE.get_uint16 buf dst_port_offset
+let set_dst_port buf v = Cstruct.BE.set_uint16 buf dst_port_offset v
+
+let get_length buf = Cstruct.BE.get_uint16 buf length_offset
+let set_length buf v = Cstruct.BE.set_uint16 buf length_offset v
+
+let get_checksum buf = Cstruct.BE.get_uint16 buf checksum_offset
+let set_checksum buf value = Cstruct.BE.set_uint16 buf checksum_offset value

--- a/src/udp/udp_wire.mli
+++ b/src/udp/udp_wire.mli
@@ -1,0 +1,13 @@
+val sizeof_udp : int
+
+val get_src_port : Cstruct.t -> int
+val set_src_port : Cstruct.t -> int -> unit
+
+val get_dst_port : Cstruct.t -> int
+val set_dst_port : Cstruct.t -> int -> unit
+
+val get_length : Cstruct.t -> int
+val set_length : Cstruct.t -> int -> unit
+
+val get_checksum : Cstruct.t -> int
+val set_checksum : Cstruct.t -> int -> unit

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -28,7 +28,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "6.0.0"}
   "cstruct-lwt"
-  "ppx_cstruct"
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
@@ -50,7 +49,8 @@ depends: [
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-random-test" {with-test & >= "0.1.0"}
-  "ipaddr-cstruct" {with-test}
+  "ipaddr-cstruct"
+  "macaddr-cstruct"
   "lru" {>= "0.3.0"}
   "metrics"
   "cmdliner" {>= "1.1.0"}

--- a/test/low_level.ml
+++ b/test/low_level.ml
@@ -34,8 +34,8 @@ let window = 5120
 
 (* Helper functions *)
 let reply_id_from ~src ~dst data =
-  let sport = Tcp_wire.get_tcp_src_port data in
-  let dport = Tcp_wire.get_tcp_dst_port data in
+  let sport = Tcp_wire.get_src_port data in
+  let dport = Tcp_wire.get_dst_port data in
   WIRE.v ~dst_port:sport ~dst:src ~src_port:dport ~src:dst
 
 let ack_for data =

--- a/test/test_checksums.ml
+++ b/test/test_checksums.ml
@@ -33,7 +33,7 @@ let udp_ipv4_correct_negative () =
 let udp_ipv4_allows_zero () =
   let buf = Cstruct.of_string example_ipv4_udp in
   let (ipv4_header, transport_packet) = unwrap_ipv4 buf in
-  Udp_wire.set_udp_checksum transport_packet 0x0000;
+  Udp_wire.set_checksum transport_packet 0x0000;
   Alcotest.(check bool) "0x0000 checksum is OK for UDP"
     true @@ verify_ipv4_udp ~ipv4_header ~transport_packet;
   Lwt.return_unit

--- a/test/test_rfc5961.ml
+++ b/test/test_rfc5961.ml
@@ -105,7 +105,7 @@ let blind_rst_on_established_scenario =
       ) else
         Lwt.return (Fsm_error "Expected final ack of three way handshake")
     | `WAIT_FOR_CHALLENGE ->
-      if (Tcp_wire.get_ack data) && (Tcp_wire.get_tcp_ack_number data = 1l)  then
+      if (Tcp_wire.get_ack data) && (Tcp_wire.get_ack_number data = 1l)  then
         Lwt.return Fsm_done
       else
         Lwt.return (Fsm_error "Challenge ack expected") in
@@ -174,7 +174,7 @@ let blind_syn_on_established_scenario =
       ) else
         Lwt.return (Fsm_error "Expected final ack of three step dance")
     | `WAIT_FOR_CHALLENGE ->
-      if (Tcp_wire.get_ack data) && (Tcp_wire.get_tcp_ack_number data = 1l)  then  (
+      if (Tcp_wire.get_ack data) && (Tcp_wire.get_ack_number data = 1l)  then  (
         Lwt.return Fsm_done
       ) else
         Lwt.return (Fsm_error "Challenge ack expected") in
@@ -208,8 +208,7 @@ let blind_data_injection_scenario =
       ) else
         Lwt.return (Fsm_error "Expected final ack of three step dance")
     | `WAIT_FOR_CHALLENGE ->
-      if (Tcp_wire.get_ack data) && (Tcp_wire.get_tcp_ack_number data =
-                                     1000001l)  then
+      if (Tcp_wire.get_ack data) && (Tcp_wire.get_ack_number data = 1000001l)  then
         Lwt.return Fsm_done
       else
         Lwt.return (Fsm_error "Challenge ack expected")
@@ -244,7 +243,7 @@ let data_repeated_ack_scenario =
       ) else
         Lwt.return (Fsm_error "Expected final ack of three step dance")
     | `WAIT_FOR_DATA_ACK ->
-      if (Tcp_wire.get_ack data) && (Tcp_wire.get_tcp_ack_number data = Int32.(add 1000001l (of_int (Cstruct.length page))))  then
+      if (Tcp_wire.get_ack data) && (Tcp_wire.get_ack_number data = Int32.(add 1000001l (of_int (Cstruct.length page))))  then
         Lwt.return Fsm_done
       else
         Lwt.return (Fsm_error "Ack for data expected") in

--- a/test/test_udp.ml
+++ b/test/test_udp.ml
@@ -39,9 +39,9 @@ let marshal_unmarshal () =
   fails "unmarshal a too-short packet" parse (Cstruct.create 2);
   let with_data = Cstruct.create 8 in
   Cstruct.memset with_data 0;
-  Udp_wire.set_udp_source_port with_data 2000;
-  Udp_wire.set_udp_dest_port with_data 21;
-  Udp_wire.set_udp_length with_data 20;
+  Udp_wire.set_src_port with_data 2000;
+  Udp_wire.set_dst_port with_data 21;
+  Udp_wire.set_length with_data 20;
   let payload = Cstruct.of_string "abcdefgh1234" in
   let with_data = Cstruct.concat [with_data; payload] in
   match Udp_packet.Unmarshal.of_cstruct with_data with


### PR DESCRIPTION
The rationale is that ppx_cstruct is more trouble than worth it:
- take a look at the intricate hoops in ipv6_wire how to retrieve the ipv6 address from a `[%%cstruct ]`
- take a look at the dependency chain: requires sexplib, which requires base, which takes several minutes to compile

Also, the tooling (merlin go to source) of ppx, and the readability is very bad (I've seen several beginners who wanted to dig into ipv6/ipv4 stack, and had a hard time to figure out where these magic functions are coming from).

Please raise your voice if you're concerned, or explain the reasoning why we should keep the ppx_cstruct around.