### PR TITLE
TCP/UDP: new function is_listening: t -> ~port:int -> callback option

### DIFF
--- a/src/core/tcp.ml
+++ b/src/core/tcp.ml
@@ -34,6 +34,7 @@ module type S = sig
   val writev_nodelay: flow -> Cstruct.t list -> (unit, write_error) result Lwt.t
   val create_connection: ?keepalive:Keepalive.t -> t -> ipaddr * int -> (flow, error) result Lwt.t
   val listen : t -> port:int -> ?keepalive:Keepalive.t -> (flow -> unit Lwt.t) -> unit
+  val is_listening : t -> port:int -> (flow -> unit Lwt.t) option
   val unlisten : t -> port:int -> unit
   val input: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
 end

--- a/src/core/tcp.mli
+++ b/src/core/tcp.mli
@@ -83,8 +83,12 @@ module type S = sig
       executed for each flow that was established. If [keepalive] is provided,
       this configuration will be applied before calling [callback].
 
-      @raise Invalid_argument if [port < 0] or [port > 65535]
- *)
+      @raise Invalid_argument if [port < 0] or [port > 65535] *)
+
+  val is_listening : t -> port:int -> (flow -> unit Lwt.t) option
+  (** [is_listening t ~port] returns the [callback] on [port], if it exists.
+
+      @raise Invalid_argument if [port < 0] or [port > 65535] *)
 
   val unlisten : t -> port:int -> unit
   (** [unlisten t ~port] stops any listener on [port]. *)

--- a/src/core/udp.ml
+++ b/src/core/udp.ml
@@ -6,6 +6,7 @@ module type S = sig
   val disconnect : t -> unit Lwt.t
   type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> Cstruct.t -> unit Lwt.t
   val listen : t -> port:int -> callback -> unit
+  val is_listening : t -> port:int -> callback option
   val unlisten : t -> port:int -> unit
   val input: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
   val write: ?src:ipaddr -> ?src_port:int -> ?ttl:int -> dst:ipaddr -> dst_port:int -> t -> Cstruct.t ->

--- a/src/core/udp.mli
+++ b/src/core/udp.mli
@@ -29,6 +29,11 @@ module type S = sig
 
       @raise Invalid_argument if [port < 0] or [port > 65535] *)
 
+  val is_listening : t -> port:int -> callback option
+  (** [is_listening t ~port] returns the [callback] on [port], if it exists.
+
+      @raise Invalid_argument if [port < 0] or [port > 65535] *)
+
   val unlisten : t -> port:int -> unit
   (** [unlisten t ~port] stops any listeners on [port]. *)
 

--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -83,6 +83,12 @@ struct
     else
       Hashtbl.replace t.listeners port (keepalive, cb)
 
+  let is_listening t ~port =
+    if port < 0 || port > 65535 then
+      raise (Invalid_argument (Printf.sprintf "invalid port number (%d)" port))
+    else
+      Option.map snd (Hashtbl.find_opt t.listeners port)
+
   let unlisten t ~port = Hashtbl.remove t.listeners port
 
   let _pp_pcb fmt pcb =

--- a/src/udp/udp.ml
+++ b/src/udp/udp.ml
@@ -40,6 +40,12 @@ module Make (Ip : Tcpip.Ip.S) (Random : Mirage_random.S) = struct
     else
       Hashtbl.replace t.listeners port callback
 
+  let is_listening t ~port =
+    if port < 0 || port > 65535 then
+      raise (Invalid_argument (Printf.sprintf "invalid port number (%d)" port))
+    else
+      Hashtbl.find_opt t.listeners port
+
   let unlisten t ~port = Hashtbl.remove t.listeners port
 
   (* TODO: ought we to check to make sure the destination is relevant


### PR DESCRIPTION
This is useful for proxies/middleware/interception of requests, a running example is let's encrypt and the HTTP challenge.

The methodology is as follows:
- the unikernel requests (via https from let's encrypt) a challenge and solves it (using a private key, some cryptographic computations)
- the let's encrypt server (wants to proof the ownership of the hostname in the certificate signing request) requests via HTTP (port 80) a specific resource (http://example.com/.well-known/acme-challenge/...)
- the unikernel needs to properly reply to that challenge

Now, one path (that we took until now) is to treat this .well-knwon/acme-challenge very special in any unikernel that we wrote.

Another path is to create a let's encrypt http challenge library that takes a stack, and whenever it needs it registers itself for port 80, proxying everything it is not interested in, to the old handler (thus, is_listening), and serving the .well-known/acme-challenge.

Concurrent updates to the "listen" hashtable are dangerous of course, great care has to be taken (if some other parts of the application as well re-register listeners). But I'm confident since listen, unlisten, and is_listening are pure (not in Lwt monad), it's fine and can be dealt with. Another option would be to implement a real protocol/locking around the shared global resource of listening ports (but I'd first see whether we run into such troubles).

Another example is the let's encrypt ALPN challenge, where the process is as follows:
- the unikernel requests (via https from let's encrypt) a challenge and solves it (using a private key, some cryptographic computations)
- the let's encrypt server (wants to proof the ownership of the hostname in the signing request) connects via TLS on port 443 with a specific ALPN string
- the unikernel needs to reply with a specially craftes self-signed certificate

This can, as above, be implemented by a temporary proxy while the challenge is in process -- without service interruptions for other parties (web browser, ...)