### PR TITLE
mirage-unix: increase TCP receive buffer size

### DIFF
--- a/src/stack-unix/tcp_socket.ml
+++ b/src/stack-unix/tcp_socket.ml
@@ -19,7 +19,7 @@ let disconnect _ =
   return_unit
 
 let read fd =
-  let buflen = 4096 in
+  let buflen = 65536 in
   let buf = Cstruct.create buflen in
   Lwt.catch (fun () ->
       Lwt_cstruct.read fd buf


### PR DESCRIPTION
Using the `iperf` code from `test_iperf.ml` (which seems to be compatible with `iperf2`, but not `iperf3`) I noticed  with `strace` that  `read` system calls use a 4KiB buffer.

Tweaking this resulted in a significant increase in speed, at least on localhost.

On `AMD Ryzen 9 7950X` using Fedora39 and OCaml 4.14.1 testing with iperf on localhost, with 4K buffer:
```
[  1] 0.00-10.00 sec  31.1 GBytes  26.7 Gbits/sec
```

With 64KiB buffer:
```
[  1] 0.00-10.00 sec  49.9 GBytes  42.9 Gbits/sec
```

The max size for various TSO/GSO/GRO packet offloads in Linux is 64KiB, so going beyond that is unlikely to be useful [1].
OCaml itself would also use a 64KiB buffer in the Unix module.

[1]: although there are plans for larger than 64KiB offloads https://netdevconf.info/0x15/slides/35/BIG%20TCP.pdf