### PR TITLE
add TCP.S.src

### DIFF
--- a/src/core/tcp.ml
+++ b/src/core/tcp.ml
@@ -30,6 +30,7 @@ module type S = sig
   and type write_error := write_error
 
   val dst: flow -> ipaddr * int
+  val src: flow -> ipaddr * int
   val write_nodelay: flow -> Cstruct.t -> (unit, write_error) result Lwt.t
   val writev_nodelay: flow -> Cstruct.t list -> (unit, write_error) result Lwt.t
   val create_connection: ?keepalive:Keepalive.t -> t -> ipaddr * int -> (flow, error) result Lwt.t

--- a/src/core/tcp.mli
+++ b/src/core/tcp.mli
@@ -53,6 +53,10 @@ module type S = sig
   (** Get the destination IP address and destination port that a
       flow is currently connected to. *)
 
+  val src : flow -> ipaddr * int
+  (** Get the source IP address and source port that a flow is currently
+      connected to. *)
+
   val write_nodelay: flow -> Cstruct.t -> (unit, write_error) result Lwt.t
   (** [write_nodelay flow buffer] writes the contents of [buffer]
       to the flow. The thread blocks until all data has been successfully

--- a/src/stack-unix/tcpv4v6_socket.ml
+++ b/src/stack-unix/tcpv4v6_socket.ml
@@ -78,6 +78,18 @@ let dst fd =
     in
     ip, port
 
+let src fd =
+  match Lwt_unix.getsockname fd with
+  | Unix.ADDR_UNIX _ ->
+    raise (Failure "unexpected: got a unix instead of tcp sock")
+  | Unix.ADDR_INET (ia,port) ->
+    let ip = Ipaddr_unix.of_inet_addr ia in
+    let ip = match Ipaddr.to_v4 ip with
+      | None -> ip
+      | Some v4 -> Ipaddr.V4 v4
+    in
+    ip, port
+
 let create_connection ?keepalive t (dst,dst_port) =
   match
     match dst, t.interface with

--- a/src/tcp/flow.ml
+++ b/src/tcp/flow.ml
@@ -637,6 +637,8 @@ struct
 
   let dst pcb = WIRE.dst pcb.id, WIRE.dst_port pcb.id
 
+  let src pcb = WIRE.src pcb.id, WIRE.src_port pcb.id
+
   let getid t dst dst_port =
     (* TODO: make this more robust and recognise when all ports are gone *)
     let islistener _t _port =


### PR DESCRIPTION
Before, we weren't able to uniquely identify a TCP flow (esp. for client connection to the same destionation host and port).

With this change, we are finally able to print a proper quad (src_ip, src_port, dst_ip, dst_port). Adding this to the interface is trivial and pretty useful.