### PR TITLE
Implement shutdown, as required by mirage-flow 4.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
+          opam-repositories: |
+            opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+            default: https://github.com/ocaml/opam-repository.git
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - run: opam install . --deps-only --with-test

--- a/src/stack-unix/tcp_socket.ml
+++ b/src/stack-unix/tcp_socket.ml
@@ -65,4 +65,12 @@ let close fd =
       | Unix.Unix_error (Unix.EBADF, _, _) -> Lwt.return_unit
       | e -> Lwt.fail e)
 
+let shutdown fd mode =
+  let cmd = match mode with
+    | `read -> Lwt_unix.SHUTDOWN_RECEIVE
+    | `write -> Lwt_unix.SHUTDOWN_SEND
+    | `read_write -> Lwt_unix.SHUTDOWN_ALL
+  in
+  Lwt.return (Lwt_unix.shutdown fd cmd)
+
 let input _t ~src:_ ~dst:_ _buf = Lwt.return_unit

--- a/src/tcp/state.ml
+++ b/src/tcp/state.ml
@@ -57,6 +57,8 @@ type t = {
 let t ~id ~on_close =
   { on_close; id; state=Closed }
 
+let on_close t = t.on_close ()
+
 let state t = t.state
 
 let pf = Format.fprintf
@@ -174,5 +176,4 @@ module Make(Time:Mirage_time.S) = struct
     Log.debug (fun fmt -> fmt "%d %a  - %a -> %a" t.id
           pp_tcpstate old_state pp_action i pp_tcpstate new_state);
     t.state <- new_state;
-
 end

--- a/src/tcp/state.mli
+++ b/src/tcp/state.mli
@@ -52,6 +52,8 @@ type t
 val state : t -> tcpstate
 val t : id:int -> on_close:close_cb -> t
 
+val on_close : t -> unit
+
 val pp: Format.formatter -> t -> unit
 
 module Make(Time : Mirage_time.S) : sig

--- a/src/tcp/user_buffer.ml
+++ b/src/tcp/user_buffer.ml
@@ -59,6 +59,13 @@ module Rx = struct
     | None -> 0
     | Some b -> Cstruct.length b
 
+  let remove_all t =
+    let rec rm = function
+      | 0 -> ()
+      | n -> ignore (Lwt_dllist.take_l t.q); rm (pred n)
+    in
+    rm (Lwt_dllist.length t.q)
+
   let add_r t s =
     if t.cur_size > t.max_size then
       let th,u = Lwt.wait () in

--- a/src/tcp/user_buffer.mli
+++ b/src/tcp/user_buffer.mli
@@ -19,6 +19,7 @@ module Rx : sig
   type t
 
   val create : max_size:int32 -> wnd:Window.t -> t
+  val remove_all : t -> unit
   val add_r : t -> Cstruct.t option -> unit Lwt.t
   val take_l : t -> Cstruct.t option Lwt.t
   val cur_size : t -> int32

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -40,7 +40,7 @@ depends: [
   "lwt-dllist"
   "logs" {>= "0.6.0"}
   "duration"
-  "randomconv"
+  "randomconv" {< "0.2.0"}
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
   "mirage-flow" {>= "4.0.0"}

--- a/tcpip.opam
+++ b/tcpip.opam
@@ -43,7 +43,7 @@ depends: [
   "randomconv"
   "ethernet" {>= "3.0.0"}
   "arp" {>= "3.0.0"}
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {>= "4.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="1.5.0"}
   "pcap-format" {with-test}


### PR DESCRIPTION
Would be great to have a review on this.

## close
From my understanding, in the UNIX sockets API the SO_LINGER is relevant (to specify how long `close()` may block) - since we don't have SO_LINGER, let's just care about the normal case (text paraphrased from https://www.cl.cam.ac.uk/~pes20/Netsem/alldoc.pdf):
- close sends any remaining data and gracefully closes the connection
- if close is called on a pre-established state: socket is closed and removed
- if on a listening socket: close and remove that socket, and aborts each of the connections on the socket's pending and completed connection queues.

If I understand, our `flow` is never a listening socket. Our `unlisten` eventually should care about the last point.

## shutdown
Depending on `` `read | `write | `read_write ``, the specific half is shut down:
- read: shutting down the read-half empties the socket’s receive queue, but data will still be delivered to it and subsequent recv() calls will return data.
- write: Shutting down the write-half of a TCP connection causes the remaining data in the socket’s send queue to be sent and then TCP’s connection termination to occur.

## TL;DR

There's some discrepancy from my intuition (and the man page shutdown(2) SHUT_RD and the model: according to the man page) "Further receives will be disallowed". In this PR, I push None to the Lwt_dllist -- with the hope that this leads to the expected behaviour (those who have knowledge about the internals should comment whether there's something else that needs to be done).