### PR TITLE
add x-maintenance-intent field to the opam file

### DIFF
--- a/tcpip.opam
+++ b/tcpip.opam
@@ -11,6 +11,7 @@ authors: [
   "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
 license: "ISC"
 tags: ["org:mirage"]
+x-maintenance-intent: [ "(latest)" ]
 
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This is my proposal - we're only interested in maintaining the very latest version of tcpip. If this is approved, I'll push that field to the opam-repository as well.