### PR TITLE
Error on attempts at writing martian packets

### DIFF
--- a/src/ipv4/routing.ml
+++ b/src/ipv4/routing.ml
@@ -36,6 +36,8 @@ module Make(Log : Logs.LOG) (A : Arp.S) = struct
           Log.info (fun f -> f "IP.output: %a" A.pp_error e);
           Error `Local
       end
+    |ip when Ipaddr.V4.Prefix.mem ip Ipaddr.V4.Prefix.loopback -> (* Loopback *)
+      Lwt.return (Error `Loopback)
     |ip -> (* Gateway *)
       match gateway with
       | None ->

--- a/src/ipv4/static_ipv4.ml
+++ b/src/ipv4/static_ipv4.ml
@@ -50,6 +50,9 @@ module Make (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
     | Error `Local ->
       Log.warn (fun f -> f "Could not find %a on the local network" Ipaddr.V4.pp dst);
       Lwt.return @@ Error (`No_route "no response for IP on local network")
+    | Error `Loopback ->
+      Log.warn (fun f -> f "Write to loopback %a dropped" Ipaddr.V4.pp dst);
+      Lwt.return @@ Error (`No_route "Loopback address")
     | Error `Gateway when t.gateway = None ->
       Log.warn (fun f -> f "Write to %a would require an external route, which was not provided" Ipaddr.V4.pp dst);
       Lwt.return @@ Ok ()

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -65,35 +65,38 @@ module Make (N : Mirage_net.S)
   let mtu t ~dst:_ = E.mtu t.ethif - Ipv6_wire.sizeof_ipv6
 
   let write t ?fragment:_ ?ttl:_ ?src dst proto ?(size = 0) headerf bufs =
-    let now = Mirage_mtime.elapsed_ns () in
-    (* TODO fragmentation! *)
-    let payload = Cstruct.concat bufs in
-    let size' = size + Cstruct.length payload in
-    let fillf _ip6hdr buf =
-      let h_len = headerf buf in
-      if h_len > size then begin
-        Log.err (fun m -> m "provided headerf exceeds size") ;
-        invalid_arg "headerf exceeds size"
-      end ;
-      Cstruct.blit payload 0 buf h_len (Cstruct.length payload);
-      h_len + Cstruct.length payload
-    in
-    let ctx, outs = Ndpv6.send ~now t.ctx ?src dst proto size' fillf in
-    t.ctx <- ctx;
-    let fail_any progress data =
-      let squeal = function
-      | Ok () as ok -> Lwt.return ok
-      | Error e ->
-        Log.warn (fun f -> f "ethif write errored: %a" E.pp_error e);
-        Lwt.return @@ Error (`Ethif e)
+    if Ipaddr.V6.(compare localhost) dst = 0 then
+      Lwt.return (Error (`No_route "Loopback address"))
+    else
+      let now = Mirage_mtime.elapsed_ns () in
+      (* TODO fragmentation! *)
+      let payload = Cstruct.concat bufs in
+      let size' = size + Cstruct.length payload in
+      let fillf _ip6hdr buf =
+        let h_len = headerf buf in
+        if h_len > size then begin
+          Log.err (fun m -> m "provided headerf exceeds size") ;
+          invalid_arg "headerf exceeds size"
+        end ;
+        Cstruct.blit payload 0 buf h_len (Cstruct.length payload);
+        h_len + Cstruct.length payload
       in
-      match progress with
-      | Ok () -> output t data >>= squeal
-      | Error e -> Lwt.return @@ Error e
-    in
-    (* MCP - it's not totally clear to me that this the right behavior
-       for writev. *)
-    Lwt_list.fold_left_s fail_any (Ok ()) outs
+      let ctx, outs = Ndpv6.send ~now t.ctx ?src dst proto size' fillf in
+      t.ctx <- ctx;
+      let fail_any progress data =
+        let squeal = function
+          | Ok () as ok -> Lwt.return ok
+          | Error e ->
+            Log.warn (fun f -> f "ethif write errored: %a" E.pp_error e);
+            Lwt.return @@ Error (`Ethif e)
+        in
+        match progress with
+        | Ok () -> output t data >>= squeal
+        | Error e -> Lwt.return @@ Error e
+      in
+      (* MCP - it's not totally clear to me that this the right behavior
+         for writev. *)
+      Lwt_list.fold_left_s fail_any (Ok ()) outs
 
   let input t ~tcp ~udp ~default buf =
     let now = Mirage_mtime.elapsed_ns () in


### PR DESCRIPTION
If we try to write to a loopback address we error out. This is perhaps not ideal, but sending IP packets with loopback addresses is not allowed according to RFC 1122.

I'm not sure what to do with such packets. Ideally, they would instead be written to a loopback interface, but I don't think we have that.

Something similar should likely be done for ipv6, and there may be other addresses which we need to handle differently.

See also #537 