### PR TITLE
Add multicast group membership (join/leave) to the IP and stack interfaces

### DIFF
--- a/src/core/ip.ml
+++ b/src/core/ip.ml
@@ -35,4 +35,6 @@ module type S = sig
   [@@ocaml.deprecated "this function will be removed soon, use [configured_ips] instead."]
   val configured_ips: t -> prefix list
   val mtu: t -> dst:ipaddr -> int
+  val join_multicast_group : t -> ipaddr -> unit Lwt.t
+  val leave_multicast_group : t -> ipaddr -> unit Lwt.t
 end

--- a/src/core/ip.ml
+++ b/src/core/ip.ml
@@ -37,4 +37,5 @@ module type S = sig
   val mtu: t -> dst:ipaddr -> int
   val join_multicast_group : t -> ipaddr -> unit Lwt.t
   val leave_multicast_group : t -> ipaddr -> unit Lwt.t
+  val multicast_groups : t -> ipaddr list
 end

--- a/src/core/ip.mli
+++ b/src/core/ip.mli
@@ -95,4 +95,15 @@ module type S = sig
   val mtu: t -> dst:ipaddr -> int
   (** [mtu ~dst ip] is the Maximum Transmission Unit of the [ip] i.e. the
       maximum size of the payload, not including the IP header. *)
+
+  val join_multicast_group : t -> ipaddr -> unit Lwt.t
+  (** [join_multicast_group t group] arranges for datagrams destined to the
+      multicast [group] to be accepted by {!input}.  For socket-based stacks
+      this performs an [IP_ADD_MEMBERSHIP], for the direct stack it records the
+      group so the input path stops discarding it.  Joining a non-multicast
+      address has no effect. *)
+
+  val leave_multicast_group : t -> ipaddr -> unit Lwt.t
+  (** [leave_multicast_group t group] reverses a previous
+      {!join_multicast_group}. *)
 end

--- a/src/core/ip.mli
+++ b/src/core/ip.mli
@@ -98,12 +98,23 @@ module type S = sig
 
   val join_multicast_group : t -> ipaddr -> unit Lwt.t
   (** [join_multicast_group t group] arranges for datagrams destined to the
-      multicast [group] to be accepted by {!input}.  For socket-based stacks
-      this performs an [IP_ADD_MEMBERSHIP], for the direct stack it records the
-      group so the input path stops discarding it.  Joining a non-multicast
-      address has no effect. *)
+      multicast [group] to be accepted by {!input}.  For the socket stacks
+      this performs an [IP_ADD_MEMBERSHIP].  For the direct stack it records
+      the group so the input path stops discarding it.  Joining an address
+      that is not multicast has no effect.
+
+      This delivers link local multicast, the [224.0.0.0/24] range (which
+      includes mDNS's [224.0.0.251]).  Switches flood that range and routers
+      never forward it, so the frames arrive without any membership
+      announcement on the wire.  Groups outside that range are not delivered,
+      because forwarding them relies on IGMP membership reports that this stack
+      does not emit. *)
 
   val leave_multicast_group : t -> ipaddr -> unit Lwt.t
   (** [leave_multicast_group t group] reverses a previous
       {!join_multicast_group}. *)
+
+  val multicast_groups : t -> ipaddr list
+  (** [multicast_groups t] is the list of multicast groups currently joined
+      via {!join_multicast_group}. *)
 end

--- a/src/core/stack.ml
+++ b/src/core/stack.ml
@@ -33,10 +33,15 @@ module type V4V6 = sig
   val join_multicast_group : t -> Ipaddr.t -> unit Lwt.t
   (** [join_multicast_group t group] joins the multicast [group] so that
       datagrams destined to it are delivered to the appropriate listeners
-      (e.g. a [UDP.listen] on the mDNS port for [224.0.0.251]).  Joining a
-      non-multicast address has no effect. *)
+      (e.g. a [UDP.listen] on the mDNS port for [224.0.0.251]).  Joining an
+      address that is not multicast has no effect.  See {!Tcpip.Ip.S} for the
+      link local scope this covers. *)
 
   val leave_multicast_group : t -> Ipaddr.t -> unit Lwt.t
   (** [leave_multicast_group t group] reverses a previous
       {!join_multicast_group}. *)
+
+  val multicast_groups : t -> Ipaddr.t list
+  (** [multicast_groups t] is the list of multicast groups currently joined
+      via {!join_multicast_group}. *)
 end

--- a/src/core/stack.ml
+++ b/src/core/stack.ml
@@ -29,4 +29,14 @@ module type V4V6 = sig
   (** [listen t] requests that the stack listen for traffic on the
       network interface associated with the stack, and demultiplex
       traffic to the appropriate callbacks. *)
+
+  val join_multicast_group : t -> Ipaddr.t -> unit Lwt.t
+  (** [join_multicast_group t group] joins the multicast [group] so that
+      datagrams destined to it are delivered to the appropriate listeners
+      (e.g. a [UDP.listen] on the mDNS port for [224.0.0.251]).  Joining a
+      non-multicast address has no effect. *)
+
+  val leave_multicast_group : t -> Ipaddr.t -> unit Lwt.t
+  (** [leave_multicast_group t group] reverses a previous
+      {!join_multicast_group}. *)
 end

--- a/src/ipv4/static_ipv4.ml
+++ b/src/ipv4/static_ipv4.ml
@@ -43,6 +43,7 @@ module Make (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
     cidr: Ipaddr.V4.Prefix.t;
     gateway: Ipaddr.V4.t option;
     mutable cache: Fragments.Cache.t;
+    mutable groups: Ipaddr.V4.Set.t; (* joined multicast groups *)
   }
 
   let write t ?(fragment = true) ?(ttl = 38) ?src dst proto ?(size = 0) headerf bufs =
@@ -140,6 +141,8 @@ module Make (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
         Ipaddr.V4.(compare ip (Prefix.address t.cidr) = 0
                    || compare ip broadcast = 0
                    || compare ip (Prefix.broadcast t.cidr) = 0)
+        (* accept datagrams for multicast groups we have joined *)
+        || (Ipaddr.V4.is_multicast ip && Ipaddr.V4.Set.mem ip t.groups)
       in
       if not (of_interest packet.dst) then begin
         Log.debug (fun m -> m "dropping IP fragment not for us or broadcast %a"
@@ -168,7 +171,21 @@ module Make (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
      else
        Arpv4.set_ips arp [Ipaddr.V4.Prefix.address cidr]) >|= fun () ->
     let cache = Fragments.Cache.empty fragment_cache_size in
-    { ethif; arp; cidr; gateway; cache }
+    { ethif; arp; cidr; gateway; cache; groups = Ipaddr.V4.Set.empty }
+
+  (* RFC 6762 §11: on a directly attached link (a tap or Solo5 net device) the
+     ethernet layer already delivers frames addressed to a multicast MAC, so
+     joining a group is a matter of no longer discarding it at IPv4 input (see
+     [of_interest]).  IGMP membership reports are only needed for non
+     link-local groups and are left as future work. *)
+  let join_multicast_group t group =
+    if Ipaddr.V4.is_multicast group then
+      t.groups <- Ipaddr.V4.Set.add group t.groups ;
+    Lwt.return_unit
+
+  let leave_multicast_group t group =
+    t.groups <- Ipaddr.V4.Set.remove group t.groups ;
+    Lwt.return_unit
 
   let disconnect _ = Lwt.return_unit
 

--- a/src/ipv4/static_ipv4.ml
+++ b/src/ipv4/static_ipv4.ml
@@ -176,8 +176,10 @@ module Make (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
   (* RFC 6762 §11: on a directly attached link (a tap or Solo5 net device) the
      ethernet layer already delivers frames addressed to a multicast MAC, so
      joining a group is a matter of no longer discarding it at IPv4 input (see
-     [of_interest]).  IGMP membership reports are only needed for non
-     link-local groups and are left as future work. *)
+     [of_interest]).  IGMP membership reports are only needed for groups
+     outside the link local [224.0.0.0/24] range.
+     TODO: emit IGMP membership reports so routable multicast groups are
+     forwarded to us. *)
   let join_multicast_group t group =
     if Ipaddr.V4.is_multicast group then
       t.groups <- Ipaddr.V4.Set.add group t.groups ;
@@ -186,6 +188,8 @@ module Make (Ethernet: Ethernet.S) (Arpv4 : Arp.S) = struct
   let leave_multicast_group t group =
     t.groups <- Ipaddr.V4.Set.remove group t.groups ;
     Lwt.return_unit
+
+  let multicast_groups t = Ipaddr.V4.Set.elements t.groups
 
   let disconnect _ = Lwt.return_unit
 

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -118,6 +118,12 @@ module Make (N : Mirage_net.S)
   let configured_ips t =
     Ndpv6.configured_ips t.ctx
 
+  (* IPv6 multicast membership (MLD) is not yet implemented, NDP already
+     receives the solicited-node groups it needs. Provided to satisfy the
+     {!Tcpip.Ip.S} interface. *)
+  let join_multicast_group _ _ = Lwt.return_unit
+  let leave_multicast_group _ _ = Lwt.return_unit
+
   let pseudoheader t ?src:source dst proto len =
     let ph = Cstruct.create (16 + 16 + 8) in
     let src = match source with None -> src t ~dst | Some x -> x in

--- a/src/ipv6/ipv6.ml
+++ b/src/ipv6/ipv6.ml
@@ -118,11 +118,12 @@ module Make (N : Mirage_net.S)
   let configured_ips t =
     Ndpv6.configured_ips t.ctx
 
-  (* IPv6 multicast membership (MLD) is not yet implemented, NDP already
-     receives the solicited-node groups it needs. Provided to satisfy the
-     {!Tcpip.Ip.S} interface. *)
+  (* NDP already receives the solicited-node groups it needs, and these stubs
+     satisfy the {!Tcpip.Ip.S} interface.
+     TODO: implement IPv6 multicast membership (MLD). *)
   let join_multicast_group _ _ = Lwt.return_unit
   let leave_multicast_group _ _ = Lwt.return_unit
+  let multicast_groups _ = []
 
   let pseudoheader t ?src:source dst proto len =
     let ph = Cstruct.create (16 + 16 + 8) in

--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -151,6 +151,10 @@ module IPV4V6
   let leave_multicast_group t = function
     | Ipaddr.V4 group -> Ipv4.leave_multicast_group t.ipv4 group
     | Ipaddr.V6 group -> Ipv6.leave_multicast_group t.ipv6 group
+
+  let multicast_groups t =
+    List.map (fun ip -> Ipaddr.V4 ip) (Ipv4.multicast_groups t.ipv4) @
+    List.map (fun ip -> Ipaddr.V6 ip) (Ipv6.multicast_groups t.ipv6)
 end
 
 module MakeV4V6
@@ -187,6 +191,7 @@ module MakeV4V6
 
   let join_multicast_group { ip; _ } group = IP.join_multicast_group ip group
   let leave_multicast_group { ip; _ } group = IP.leave_multicast_group ip group
+  let multicast_groups { ip; _ } = IP.multicast_groups ip
 
   let listen t =
     Lwt.catch (fun () ->

--- a/src/stack-direct/tcpip_stack_direct.ml
+++ b/src/stack-direct/tcpip_stack_direct.ml
@@ -143,6 +143,14 @@ module IPV4V6
   let mtu t ~dst = match dst with
     | Ipaddr.V4 dst -> Ipv4.mtu t.ipv4 ~dst
     | Ipaddr.V6 dst -> Ipv6.mtu t.ipv6 ~dst
+
+  let join_multicast_group t = function
+    | Ipaddr.V4 group -> Ipv4.join_multicast_group t.ipv4 group
+    | Ipaddr.V6 group -> Ipv6.join_multicast_group t.ipv6 group
+
+  let leave_multicast_group t = function
+    | Ipaddr.V4 group -> Ipv4.leave_multicast_group t.ipv4 group
+    | Ipaddr.V6 group -> Ipv6.leave_multicast_group t.ipv6 group
 end
 
 module MakeV4V6
@@ -176,6 +184,9 @@ module MakeV4V6
   let tcp { tcp; _ } = tcp
   let udp { udp; _ } = udp
   let ip { ip; _ } = ip
+
+  let join_multicast_group { ip; _ } group = IP.join_multicast_group ip group
+  let leave_multicast_group { ip; _ } group = IP.leave_multicast_group ip group
 
   let listen t =
     Lwt.catch (fun () ->

--- a/src/stack-unix/ipv4_socket.ml
+++ b/src/stack-unix/ipv4_socket.ml
@@ -40,3 +40,4 @@ let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")
 
 let join_multicast_group _ _ = Lwt.return_unit
 let leave_multicast_group _ _ = Lwt.return_unit
+let multicast_groups _ = []

--- a/src/stack-unix/ipv4_socket.ml
+++ b/src/stack-unix/ipv4_socket.ml
@@ -37,3 +37,6 @@ let get_ip _ = [Ipaddr.V4.any]
 let configured_ips _ = [Ipaddr.V4.Prefix.global]
 let src _ ~dst:_ = raise (Failure "Not implemented")
 let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")
+
+let join_multicast_group _ _ = Lwt.return_unit
+let leave_multicast_group _ _ = Lwt.return_unit

--- a/src/stack-unix/ipv4v6_socket.ml
+++ b/src/stack-unix/ipv4v6_socket.ml
@@ -39,3 +39,6 @@ let get_ip _ = [Ipaddr.V6 Ipaddr.V6.unspecified]
 let configured_ips _ = [Ipaddr.Prefix.of_string_exn "::/0"]
 let src _ ~dst:_ = raise (Failure "Not implemented")
 let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")
+
+let join_multicast_group _ _ = Lwt.return_unit
+let leave_multicast_group _ _ = Lwt.return_unit

--- a/src/stack-unix/ipv4v6_socket.ml
+++ b/src/stack-unix/ipv4v6_socket.ml
@@ -42,3 +42,4 @@ let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")
 
 let join_multicast_group _ _ = Lwt.return_unit
 let leave_multicast_group _ _ = Lwt.return_unit
+let multicast_groups _ = []

--- a/src/stack-unix/ipv6_socket.ml
+++ b/src/stack-unix/ipv6_socket.ml
@@ -41,3 +41,4 @@ let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")
 
 let join_multicast_group _ _ = Lwt.return_unit
 let leave_multicast_group _ _ = Lwt.return_unit
+let multicast_groups _ = []

--- a/src/stack-unix/ipv6_socket.ml
+++ b/src/stack-unix/ipv6_socket.ml
@@ -38,3 +38,6 @@ let get_ip _ = [Ipaddr.V6.unspecified]
 let configured_ips _ = [Ipaddr.V6.Prefix.of_string_exn "::/0"]
 let src _ ~dst:_ = raise (Failure "Not implemented")
 let pseudoheader _ ?src:_ _ _ _ = raise (Failure "Not implemented")
+
+let join_multicast_group _ _ = Lwt.return_unit
+let leave_multicast_group _ _ = Lwt.return_unit

--- a/src/stack-unix/tcpip_stack_socket.ml
+++ b/src/stack-unix/tcpip_stack_socket.ml
@@ -37,6 +37,7 @@ module V4V6 = struct
 
   let join_multicast_group { udp; _ } group = UDP.join_multicast_group udp group
   let leave_multicast_group { udp; _ } group = UDP.leave_multicast_group udp group
+  let multicast_groups { udp; _ } = UDP.multicast_groups udp
 
   let listen t = t.switched_off
 

--- a/src/stack-unix/tcpip_stack_socket.ml
+++ b/src/stack-unix/tcpip_stack_socket.ml
@@ -35,6 +35,9 @@ module V4V6 = struct
   let tcp { tcp; _ } = tcp
   let ip _ = ()
 
+  let join_multicast_group { udp; _ } group = UDP.join_multicast_group udp group
+  let leave_multicast_group { udp; _ } group = UDP.leave_multicast_group udp group
+
   let listen t = t.switched_off
 
   let connect udp tcp =

--- a/src/stack-unix/udpv4v6_socket.ml
+++ b/src/stack-unix/udpv4v6_socket.ml
@@ -158,6 +158,8 @@ let leave_multicast_group t group =
     t.listen_fds ;
   Lwt.return_unit
 
+let multicast_groups t = t.groups
+
 let disconnect t =
   Hashtbl.fold (fun _ (fd, fd') r ->
       r >>= fun () ->

--- a/src/stack-unix/udpv4v6_socket.ml
+++ b/src/stack-unix/udpv4v6_socket.ml
@@ -28,8 +28,22 @@ let any_v6 = Ipaddr_unix.V6.to_inet_addr Ipaddr.V6.unspecified
 type t = {
   interface: [ `Any | `Ip of Unix.inet_addr * Unix.inet_addr | `V4_only of Unix.inet_addr | `V6_only of Unix.inet_addr ]; (* source ip to bind to *)
   listen_fds: (int, Lwt_unix.file_descr * Lwt_unix.file_descr option) Hashtbl.t; (* UDP fds bound to a particular port *)
+  mutable groups : Ipaddr.t list; (* joined multicast groups; applied to each listening fd *)
   mutable switched_off : unit Lwt.t;
 }
+
+(* Best-effort IP_ADD_MEMBERSHIP on a bound fd.  A v4 group on the default
+   dual-stack (PF_INET6) socket can fail, we log and carry on rather than
+   abort the join. *)
+let apply_membership add fd group =
+  try
+    let inet = Ipaddr_unix.to_inet_addr group in
+    if add then Lwt_unix.mcast_add_membership fd inet
+    else Lwt_unix.mcast_drop_membership fd inet
+  with exn ->
+    Log.warn (fun m -> m "multicast %s of %a failed: %s"
+                 (if add then "join" else "leave") Ipaddr.pp group
+                 (Printexc.to_string exn))
 
 let set_switched_off t switched_off =
   t.switched_off <- Lwt.pick [ switched_off; t.switched_off ]
@@ -38,7 +52,7 @@ let ignore_canceled = function
   | Lwt.Canceled -> Lwt.return_unit
   | exn -> raise exn
 
-let get_udpv4v6_listening_fd ?(preserve = true) ?(v4_or_v6 = `Both) {listen_fds;interface;_} port =
+let get_udpv4v6_listening_fd ?(preserve = true) ?(v4_or_v6 = `Both) {listen_fds;interface;groups;_} port =
   try
     Lwt.return
       (match Hashtbl.find listen_fds port with
@@ -77,7 +91,11 @@ let get_udpv4v6_listening_fd ?(preserve = true) ?(v4_or_v6 = `Both) {listen_fds;
        let fd = Lwt_unix.(socket PF_INET6 SOCK_DGRAM 0) in
        Lwt_unix.bind fd (Lwt_unix.ADDR_INET (ip, port)) >|= fun () ->
        ((fd, None), [ fd ])) >|= fun (fds, r) ->
-    if preserve then Hashtbl.add listen_fds port fds;
+    if preserve then begin
+      Hashtbl.add listen_fds port fds;
+      (* apply any already-joined multicast groups to the freshly bound fd(s) *)
+      List.iter (fun fd -> List.iter (apply_membership true fd) groups) r
+    end;
     true, r
 
 
@@ -118,7 +136,27 @@ let connect ~ipv4_only ~ipv6_only ipv4 ipv6 =
           `Ip (v4_unix, Ipaddr_unix.V6.to_inet_addr v6)
   in
   let listen_fds = Hashtbl.create 7 in
-  Lwt.return { interface; listen_fds; switched_off = fst (Lwt.wait ()) }
+  Lwt.return { interface; listen_fds; groups = []; switched_off = fst (Lwt.wait ()) }
+
+(* Join a multicast group (IP_ADD_MEMBERSHIP).  The group is remembered and
+   applied to every currently bound fd as well as to fds bound later by
+   [listen] (see [get_udpv4v6_listening_fd]). *)
+let join_multicast_group t group =
+  if not (List.exists (fun g -> Ipaddr.compare g group = 0) t.groups) then
+    t.groups <- group :: t.groups ;
+  Hashtbl.iter (fun _ (fd, fd') ->
+      apply_membership true fd group ;
+      Option.iter (fun fd -> apply_membership true fd group) fd')
+    t.listen_fds ;
+  Lwt.return_unit
+
+let leave_multicast_group t group =
+  t.groups <- List.filter (fun g -> Ipaddr.compare g group <> 0) t.groups ;
+  Hashtbl.iter (fun _ (fd, fd') ->
+      apply_membership false fd group ;
+      Option.iter (fun fd -> apply_membership false fd group) fd')
+    t.listen_fds ;
+  Lwt.return_unit
 
 let disconnect t =
   Hashtbl.fold (fun _ (fd, fd') r ->


### PR DESCRIPTION
Adds join_multicast_group / leave_multicast_group to Tcpip.Ip.S and Tcpip.Stack.V4V6 so a stack can receive datagrams sent to a multicast group (the capability requested in #362 and #498) and what mDNS/DNS-SD (RFC 6762/6763) needs to answer queries on 224.0.0.251.
 
**Problem:** No way to join a group: the direct IPv4 stack drops any non-own-address/non-broadcast destination (static_ipv4.ml of_interest), the socket stack never issues IP_ADD_MEMBERSHIP. So a responder can announce but never receive.

**Change**
We add these functions to join and leave a multicast group:

``` ocaml
val join_multicast_group  : t -> ipaddr -> unit Lwt.t
val leave_multicast_group : t -> ipaddr -> unit Lwt.t
```

- Direct IPv4 (static_ipv4): tracks joined groups and accepts datagrams addressed to them at input. This is sufficient for **link-local** multicast (the `224.0.0.0/24` range, which includes mDNS's `224.0.0.251`) because switches flood that range and routers never forward it, so frames arrive without any on-wire membership announcement (ethernet already admits the multicast MAC). **Routable (non-link-local) groups** additionally require IGMP membership reports so the network forwards their traffic. Sending those, together with an IGMP implementation, which mirage-tcpip currently lacks, is left as future work.
- Dual stack (IPV4V6): routes to v4/v6; IPv6 MLD is a no-op for now.
- Socket UDP (udpv4v6_socket): IP_ADD_MEMBERSHIP on each bound fd and fds bound later, v4-on-dual-stack is best-effort (logged).
- Socket IP shim + v6 socket: no-op. Defaults preserve existing behaviour.

*Testing*: Wired into a MirageOS mDNS responder (dns-mdns-mirage) that I'm working on, it joins 224.0.0.251 at startup and is then discovered and resolved by stock Avahi, on both the unix target (direct stack over a tap) and Solo5/spt. Without this change the direct stack drops the queries and the responder is invisible.

Closes #362, #498.